### PR TITLE
Added simple `use_state` proc_macro

### DIFF
--- a/kayak_render_macros/src/lib.rs
+++ b/kayak_render_macros/src/lib.rs
@@ -15,7 +15,7 @@ use partial_eq::impl_dyn_partial_eq;
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 use quote::quote;
-use syn::{parse_macro_input, parse_quote};
+use syn::{Expr, parse_macro_input, parse_quote};
 use widget::ConstructedWidget;
 
 use crate::widget::Widget;
@@ -94,4 +94,53 @@ pub fn dyn_partial_eq(_: TokenStream, input: TokenStream) -> TokenStream {
       }
     })
     .into()
+}
+
+
+/// Create a state and its setter
+///
+/// # Arguments
+///
+/// * `initial_state`: The expression
+///
+/// returns: (state, set_state)
+///
+/// # Examples
+///
+/// ```
+/// # use kayak_core::{EventType, OnEvent};
+/// use kayak_render_macros::use_state;
+///
+/// let (count, set_count) = use_state!(0);
+///
+/// let on_event = OnEvent::new(move |_, event| match event.event_type {
+///         EventType::Click => {
+///             set_count(foo + 1);
+///         }
+///         _ => {}
+/// });
+///
+/// rsx! {
+///         <>
+///             <Button on_event={Some(on_event)}>
+///                 <Text size={16.0} content={format!("Count: {}", count)}>{}</Text>
+///             </Button>
+///         </>
+///     }
+/// ```
+#[proc_macro]
+pub fn use_state(initial_state: TokenStream) -> TokenStream {
+    let initial_state = parse_macro_input!(initial_state as Expr);
+    let result = quote! {{
+        let state = context.create_state(#initial_state).unwrap();
+        let cloned_state = state.clone();
+        let set_state = move |value| {
+            cloned_state.set(value);
+        };
+
+        let state_value = state.get();
+
+        (state.get(), set_state)
+    }};
+    TokenStream::from(result)
 }

--- a/kayak_render_macros/src/lib.rs
+++ b/kayak_render_macros/src/lib.rs
@@ -15,7 +15,7 @@ use partial_eq::impl_dyn_partial_eq;
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 use quote::quote;
-use syn::{Expr, parse_macro_input, parse_quote};
+use syn::{parse_macro_input, parse_quote};
 use widget::ConstructedWidget;
 
 use crate::widget::Widget;
@@ -130,7 +130,7 @@ pub fn dyn_partial_eq(_: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn use_state(initial_state: TokenStream) -> TokenStream {
-    let initial_state = parse_macro_input!(initial_state as Expr);
+    let initial_state = parse_macro_input!(initial_state as syn::Expr);
     let result = quote! {{
         let state = context.create_state(#initial_state).unwrap();
         let cloned_state = state.clone();


### PR DESCRIPTION
> This PR might be a bit controversial, so no worries if it isn't merged.

## Goal

Condense the boilerplate of setting up a state into a single macro.

## Solution

This PR adds a proc_macro called `use_state` that condenses the boilerplate from this:

```rust
// Create state
let count = context.create_state(0i32).unwrap();

// Set state
let cloned_count = count.clone();
let on_event = OnEvent::new(move |_, event| match event.event_type {
    EventType::Click => {
        cloned_count.set(cloned_count.get() + 1);
    }
    _ => {}
});

// Get state
let count_value = count.get();
```

to this:

```rust
let (count, set_count) = use_state!(0i32);
let on_event = OnEvent::new(move |_, event| match event.event_type {
    EventType::Click => {
        set_count(count + 1);
    }
    _ => {}
});
```

### Benefits

Obviously the main benefit is that it reduces what the user has to write. But another plus is that it allows us to control how state is created, updated, and retrieved. This allows us to introduce more API changes without users necessarily needing to change their code.

### Downsides

It hides a bit of what's happening under the hood. You need to have access to a `&mut KayakContext` that is actually named `context` (maybe we could add a (optional?) parameter that passes in the actual context so we don't have to make that assumption).

Additionally, it may be too early for such convenience macros if we expect there to be lots of API changes.

And, of course, the name (deriving from [React](https://reactjs.org/docs/hooks-state.html)) might be confusing to some people. We have the option of choosing another name, but I went with `use_state` since I come from a React background.