### PR TITLE
Fixed backspace for textbox input

### DIFF
--- a/kayak_widgets/src/text_box.rs
+++ b/kayak_widgets/src/text_box.rs
@@ -63,7 +63,7 @@ pub fn TextBox(value: String, on_change: Option<OnChange>) {
             if !cloned_has_focus.get().0 {
                 return;
             }
-            if c == '\u{8}' {
+            if is_backspace(c) {
                 if current_value.len() > 0 {
                     current_value.truncate(current_value.len() - 1);
                 }
@@ -91,4 +91,11 @@ pub fn TextBox(value: String, on_change: Option<OnChange>) {
             </Clip>
         </Background>
     }
+}
+
+/// Checks if the given character contains the "Backspace" sequence
+///
+/// Context: [Wikipedia](https://en.wikipedia.org/wiki/Backspace#Common_use)
+fn is_backspace(c: char) -> bool {
+    c == '\u{8}' || c == '\u{7f}'
 }


### PR DESCRIPTION
Textbox wasn't checking for `'0x7f'` (another common backspace sequence). Added a check for that and extracted it to a separate function for clarity.