### PR TITLE
Extracted ChangeEvent and made it generic

### DIFF
--- a/examples/text_box.rs
+++ b/examples/text_box.rs
@@ -3,13 +3,14 @@ use bevy::{
     window::WindowDescriptor,
     DefaultPlugins,
 };
+use kayak_core::OnChange;
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
 use kayak_ui::core::{
     render, rsx,
     styles::{Style, StyleProp, Units},
     widget, Bound, Index, MutableBound,
 };
-use kayak_widgets::{App, OnChange, TextBox, Window};
+use kayak_widgets::{App, TextBox, Window};
 
 #[widget]
 fn TextBoxExample(context: &mut KayakContext) {

--- a/examples/text_box.rs
+++ b/examples/text_box.rs
@@ -25,12 +25,12 @@ fn TextBoxExample(context: &mut KayakContext) {
     };
 
     let cloned_value = value.clone();
-    let on_change = OnChange::new(move |event| {
+    let on_change = OnChange::new_handler(move |event| {
         cloned_value.set(event.value);
     });
 
     let cloned_value2 = value2.clone();
-    let on_change2 = OnChange::new(move |event| {
+    let on_change2 = OnChange::new_handler(move |event| {
         cloned_value2.set(event.value);
     });
 

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -49,8 +49,16 @@ pub struct ChangeEvent<T> {
 pub struct OnChange<T>(pub Arc<RwLock<dyn FnMut(ChangeEvent<T>) + Send + Sync + 'static>>);
 
 impl<T> OnChange<T> {
+    /// Create a new handler for a [ChangeEvent]
     pub fn new<F: FnMut(ChangeEvent<T>) + Send + Sync + 'static>(f: F) -> Self {
         Self(Arc::new(RwLock::new(f)))
+    }
+
+    /// Send the given event to be handled by the current handler
+    pub fn send(&self, event: ChangeEvent<T>) {
+        if let Ok(mut on_change) = self.0.write() {
+            on_change(event);
+        }
     }
 }
 

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -1,3 +1,4 @@
+use std::sync::{Arc, RwLock};
 use crate::{Index, KeyCode};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -27,4 +28,40 @@ pub enum EventType {
     Blur,
     CharInput { c: char },
     KeyboardInput { key: KeyCode },
+}
+
+/// An event denoting a change of some type
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChangeEvent<T> {
+    pub value: T,
+}
+
+/// A handler struct for a [ChangeEvent].
+///
+/// ## Example
+/// ```rust
+/// let handler = OnChange::new(move |event| {
+///     let value = event.value;
+///     // Do something...
+/// });
+/// ```
+#[derive(Clone)]
+pub struct OnChange<T>(pub Arc<RwLock<dyn FnMut(ChangeEvent<T>) + Send + Sync + 'static>>);
+
+impl<T> OnChange<T> {
+    pub fn new<F: FnMut(ChangeEvent<T>) + Send + Sync + 'static>(f: F) -> Self {
+        Self(Arc::new(RwLock::new(f)))
+    }
+}
+
+impl<T> PartialEq for OnChange<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<T> std::fmt::Debug for OnChange<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("OnChange").finish()
+    }
 }

--- a/kayak_widgets/src/text_box.rs
+++ b/kayak_widgets/src/text_box.rs
@@ -1,44 +1,20 @@
+use std::sync::{Arc, RwLock};
+
 use kayak_ui::core::{
+    Bound, ChangeEvent, Color, EventType, MutableBound, OnChange, OnEvent,
     render_command::RenderCommand,
     rsx,
     styles::{Style, StyleProp, Units},
-    widget, Bound, Color, EventType, MutableBound, OnEvent,
+    widget
 };
-use std::sync::{Arc, RwLock};
 
 use crate::{Background, Clip, Text};
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct ChangeEvent {
-    pub value: String,
-}
-
-#[derive(Clone)]
-pub struct OnChange(pub Arc<RwLock<dyn FnMut(ChangeEvent) + Send + Sync + 'static>>);
-
-impl OnChange {
-    pub fn new<F: FnMut(ChangeEvent) + Send + Sync + 'static>(f: F) -> OnChange {
-        OnChange(Arc::new(RwLock::new(f)))
-    }
-}
-
-impl PartialEq for OnChange {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl std::fmt::Debug for OnChange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("OnChange").finish()
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Focus(pub bool);
 
 #[widget(focusable)]
-pub fn TextBox(value: String, on_change: Option<OnChange>) {
+pub fn TextBox(value: String, on_change: Option<OnChange<String>>) {
     *styles = Some(Style {
         render_command: StyleProp::Value(RenderCommand::Layout),
         ..styles.clone().unwrap_or_default()

--- a/kayak_widgets/src/text_box.rs
+++ b/kayak_widgets/src/text_box.rs
@@ -47,11 +47,9 @@ pub fn TextBox(value: String, on_change: Option<OnChange<String>>) {
                 current_value.push(c);
             }
             if let Some(on_change) = cloned_on_change.as_ref() {
-                if let Ok(mut on_change) = on_change.0.write() {
-                    on_change(ChangeEvent {
-                        value: current_value.clone(),
-                    });
-                }
+                on_change.send(ChangeEvent {
+                    value: current_value.clone(),
+                });
             }
         }
         EventType::Focus => cloned_has_focus.set(Focus(true)),


### PR DESCRIPTION
## Goal

The `ChangeEvent` from `kayak_widgets/src/text_box.rs` could be useful for callbacks in other widgets. This logic could be moved to `kayak_core` so that it may be used in other scenarios.

## Solution

Extracted the `ChangeEvent` from `kayak_widgets/src/text_box.rs` and added it to `kayak_core`.

Also made the event generic so that values of any type could be sent (e.g. `ChangeEvent<bool>`, `ChangeEvent<MyStruct>`, etc.).

## Notes

This might change if props become restricted to `Binding<T>` types, but could be a decent addition in the meantime.