### PR TITLE
Separated `KeyboardInput` into `KeyUp` and `KeyDown` events

### DIFF
--- a/bevy_kayak_ui/src/lib.rs
+++ b/bevy_kayak_ui/src/lib.rs
@@ -93,6 +93,7 @@ pub fn process_events(
                 let kayak_key_code = key::convert_virtual_key_code(key_code);
                 input_events.push(InputEvent::Keyboard {
                     key: kayak_key_code,
+                    is_pressed: matches!(event.state, ElementState::Pressed)
                 });
             }
         }

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -59,7 +59,8 @@ pub enum EventType {
     Focus,
     Blur,
     CharInput { c: char },
-    KeyboardInput { key: KeyCode },
+    KeyUp { key: KeyCode },
+    KeyDown { key: KeyCode },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -82,7 +83,8 @@ impl EventType {
             Self::MouseDown => true,
             Self::MouseUp => true,
             Self::CharInput { .. } => true,
-            Self::KeyboardInput { .. } => true,
+            Self::KeyUp { .. } => true,
+            Self::KeyDown { .. } => true,
             // Doesn't Propagate
             Self::MouseIn => false,
             Self::MouseOut => false,
@@ -103,7 +105,8 @@ impl EventType {
             Self::MouseOut => EventCategory::Mouse,
             // Keyboard
             Self::CharInput { .. } => EventCategory::Keyboard,
-            Self::KeyboardInput { .. } => EventCategory::Keyboard,
+            Self::KeyUp { .. } => EventCategory::Keyboard,
+            Self::KeyDown { .. } => EventCategory::Keyboard,
             // Focus
             Self::Focus => EventCategory::Focus,
             Self::Blur => EventCategory::Focus,

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -1,4 +1,4 @@
-use crate::{Index, KeyCode};
+use crate::{Index, KeyboardEvent};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event {
@@ -59,8 +59,8 @@ pub enum EventType {
     Focus,
     Blur,
     CharInput { c: char },
-    KeyUp { key: KeyCode },
-    KeyDown { key: KeyCode },
+    KeyUp(KeyboardEvent),
+    KeyDown(KeyboardEvent),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -83,8 +83,8 @@ impl EventType {
             Self::MouseDown => true,
             Self::MouseUp => true,
             Self::CharInput { .. } => true,
-            Self::KeyUp { .. } => true,
-            Self::KeyDown { .. } => true,
+            Self::KeyUp(..) => true,
+            Self::KeyDown(..) => true,
             // Doesn't Propagate
             Self::MouseIn => false,
             Self::MouseOut => false,
@@ -105,8 +105,8 @@ impl EventType {
             Self::MouseOut => EventCategory::Mouse,
             // Keyboard
             Self::CharInput { .. } => EventCategory::Keyboard,
-            Self::KeyUp { .. } => EventCategory::Keyboard,
-            Self::KeyDown { .. } => EventCategory::Keyboard,
+            Self::KeyUp(..) => EventCategory::Keyboard,
+            Self::KeyDown(..) => EventCategory::Keyboard,
             // Focus
             Self::Focus => EventCategory::Focus,
             Self::Blur => EventCategory::Focus,

--- a/kayak_core/src/event_dispatcher.rs
+++ b/kayak_core/src/event_dispatcher.rs
@@ -303,9 +303,15 @@ impl EventDispatcher {
                 InputEvent::CharEvent { c } => event_stream.push(
                     Event::new(current_focus, EventType::CharInput { c: *c })
                 ),
-                InputEvent::Keyboard { key } => event_stream.push(
-                    Event::new(current_focus, EventType::KeyboardInput { key: *key })
-                ),
+                InputEvent::Keyboard { key, is_pressed } => if *is_pressed {
+                    event_stream.push(
+                        Event::new(current_focus, EventType::KeyDown { key: *key })
+                    )
+                } else {
+                    event_stream.push(
+                        Event::new(current_focus, EventType::KeyUp { key: *key })
+                    )
+                }
                 _ => {}
             }
         }

--- a/kayak_core/src/input_event.rs
+++ b/kayak_core/src/input_event.rs
@@ -6,7 +6,7 @@ pub enum InputEvent {
     MouseLeftPress,
     MouseLeftRelease,
     CharEvent { c: char },
-    Keyboard { key: KeyCode },
+    Keyboard { key: KeyCode, is_pressed: bool },
 }
 
 pub enum InputEventCategory {

--- a/kayak_core/src/keyboard.rs
+++ b/kayak_core/src/keyboard.rs
@@ -1,0 +1,62 @@
+use crate::KeyCode;
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct KeyboardModifiers {
+    /// True if the one of the Control keys is currently pressed
+    pub is_ctrl_pressed: bool,
+    /// True if the one of the Shift keys is currently pressed
+    pub is_shift_pressed: bool,
+    /// True if the one of the Alt (or "Option") keys is currently pressed
+    pub is_alt_pressed: bool,
+    /// True if the one of the Meta keys is currently pressed
+    ///
+    /// This is the "Command" ("⌘") key on Mac and "Windows" or "Super" on other systems.
+    pub is_meta_pressed: bool,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct KeyboardEvent {
+    key: KeyCode,
+    modifiers: KeyboardModifiers,
+}
+
+impl KeyboardEvent {
+    pub fn new(key: KeyCode, modifiers: KeyboardModifiers) -> Self {
+        Self {
+            key,
+            modifiers,
+        }
+    }
+
+    /// Returns this event's affected key
+    pub fn key(&self) -> KeyCode {
+        self.key
+    }
+
+    /// Returns all modifiers for this event's key
+    pub fn modifiers(&self) -> KeyboardModifiers {
+        self.modifiers
+    }
+
+    /// Returns true if the one of the Control keys is currently pressed
+    pub fn is_ctrl_pressed(&self) -> bool {
+        self.modifiers.is_ctrl_pressed
+    }
+
+    /// Returns true if the one of the Shift keys is currently pressed
+    pub fn is_shift_pressed(&self) -> bool {
+        self.modifiers.is_shift_pressed
+    }
+
+    /// Returns true if the one of the Alt (or "Option") keys is currently pressed
+    pub fn is_alt_pressed(&self) -> bool {
+        self.modifiers.is_alt_pressed
+    }
+
+    /// Returns true if the one of the Meta keys is currently pressed
+    ///
+    /// This is the "Command" ("⌘") key on Mac and "Windows" or "Super" on other systems.
+    pub fn is_meta_pressed(&self) -> bool {
+        self.modifiers.is_meta_pressed
+    }
+}

--- a/kayak_core/src/lib.rs
+++ b/kayak_core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod widget;
 pub mod widget_manager;
 mod cursor;
 mod event_dispatcher;
+mod keyboard;
 
 use std::sync::{Arc, RwLock};
 
@@ -29,11 +30,13 @@ pub use event::*;
 pub use fragment::Fragment;
 pub use generational_arena::{Arena, Index};
 pub use input_event::*;
+pub use keyboard::{KeyboardEvent, KeyboardModifiers};
 pub use keys::KeyCode;
 pub use resources::Resources;
 pub use tree::{Tree, WidgetTree};
 pub use vec::VecTracker;
 pub use widget::Widget;
+
 pub mod derivative {
     pub use derivative::*;
 }
@@ -44,7 +47,7 @@ pub type Children = Option<
 
 #[derive(Clone)]
 pub struct OnEvent(
-    pub  Arc<
+    pub Arc<
         RwLock<dyn FnMut(&mut crate::context::KayakContext, &mut Event) + Send + Sync + 'static>,
     >,
 );


### PR DESCRIPTION
Split the `KeyboardInput` event into separate `KeyUp` and `KeyDown` events. Before, we were receiving two events for every press/release of a key when we should only be receiving one.

~~One possible oddity, is that the `KeyDown` event fires for every repeat (as long as the key is held down).~~ Apparently this [also happens for HTML](https://jsfiddle.net/zdgaj8mx/), so maybe this is fine?

Additionally, added a `KeyboardEvent` struct that allows us to pass along metadata with these new events (they replaced the single `key` variant member). It stores a `KeyboardModifiers` struct that contains which modifier keys are actively being pressed (something we can't know using the old system— not easily at least).

Again, I used W3's [specifications](https://www.w3.org/TR/uievents/#events-keyboard-types) for reference, but we don't strictly need to follow those to a T. So let me know if there's a different way we should be going about things here!
