### PR TITLE
Enforced bounds on `create_widget` and `VecTracker`

### DIFF
--- a/kayak_core/src/fragment.rs
+++ b/kayak_core/src/fragment.rs
@@ -3,7 +3,7 @@ use derivative::*;
 use crate::{context::KayakContext, styles::Style, Index, Widget};
 
 #[derive(Derivative)]
-#[derivative(Default, Debug, PartialEq)]
+#[derivative(Default, Debug, PartialEq, Clone)]
 pub struct Fragment {
     pub id: Index,
     #[derivative(Default(value = "None"))]

--- a/kayak_core/src/vec.rs
+++ b/kayak_core/src/vec.rs
@@ -3,13 +3,14 @@ use derivative::*;
 use crate::{context::KayakContext, styles::Style, Index, Widget};
 
 #[derive(Derivative)]
-#[derivative(Debug, PartialEq, Clone)]
+#[derivative(Debug, PartialEq, Clone, Default)]
 pub struct VecTracker<T> {
     pub id: Index,
+    #[derivative(Default(value = "None"))]
     pub styles: Option<Style>,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derivative(Default(value = "None"), Debug = "ignore", PartialEq = "ignore")]
     pub children: crate::Children,
-    #[derivative(Debug = "ignore", PartialEq = "ignore")]
+    #[derivative(Default(value = "None"), Debug = "ignore", PartialEq = "ignore")]
     pub on_event: Option<crate::OnEvent>,
     pub data: Vec<T>,
 }
@@ -37,7 +38,7 @@ where
 
 impl<T> Widget for VecTracker<T>
 where
-    T: Widget + PartialEq + std::fmt::Debug + Clone,
+    T: Widget + PartialEq + std::fmt::Debug + Clone + Default,
 {
     fn get_id(&self) -> Index {
         self.id

--- a/kayak_core/src/widget_manager.rs
+++ b/kayak_core/src/widget_manager.rs
@@ -58,7 +58,7 @@ impl WidgetManager {
         }
     }
 
-    pub fn create_widget<T: Widget + PartialEq + 'static>(
+    pub fn create_widget<T: Widget + PartialEq + Default + Clone + 'static>(
         &mut self,
         index: usize,
         mut widget: T,


### PR DESCRIPTION
The `WidgetManager::create_widget` method was missing some bounds (`Default` and `Clone`). Additionally, updated `Fragment` and `VecTracker` to derive their missing traits.