### PR TITLE
Added methods to dump tree state to console

### DIFF
--- a/kayak_core/src/tree.rs
+++ b/kayak_core/src/tree.rs
@@ -6,7 +6,7 @@ use std::{
 
 use morphorm::Hierarchy;
 
-use crate::Index;
+use crate::{Arena, Index, Widget};
 
 #[derive(Default, Debug, PartialEq)]
 pub struct Tree {

--- a/kayak_core/src/tree.rs
+++ b/kayak_core/src/tree.rs
@@ -436,6 +436,57 @@ impl Tree {
         //     );
         // }
     }
+    
+    
+    /// Dumps the tree's current state to the console
+    ///
+    /// To dump only a section of the tree, use [dump_at] instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `widgets`: Optionally, provide the current widgets to include metadata about each widget
+    ///
+    /// returns: ()
+    pub fn dump(&self, widgets: Option<&Arena<Option<Box<dyn Widget>>>>) {
+        if let Some(root) = self.root_node {
+            self.dump_at_internal(root, 0, widgets);
+        }
+    }
+
+    /// Dumps a section of the tree's current state to the console (starting from a specific index)
+    ///
+    /// To dump the entire tree, use [dump] instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_index`: The index to start recursing from (including itself)
+    /// * `widgets`: Optionally, provide the current widgets to include metadata about each widget
+    ///
+    /// returns: ()
+    pub fn dump_at(&self, start_index: Index, widgets: Option<&Arena<Option<Box<dyn Widget>>>>) {
+        self.dump_at_internal(start_index, 0, widgets);
+    }
+
+    fn dump_at_internal(&self, start_index: Index, depth: usize, widgets: Option<&Arena<Option<Box<dyn Widget>>>>) {
+        let mut name = None;
+        if let Some(widgets) = widgets {
+            if let Some(widget) = widgets.get(start_index) {
+                if let Some(widget) = widget {
+                    name = Some(widget.get_name());
+                }
+            }
+        }
+
+        let indent = "\t".repeat(depth);
+        let raw_parts = start_index.into_raw_parts();
+        println!("{}{} [{}:{}]", indent, name.unwrap_or_default(), raw_parts.0, raw_parts.1);
+
+        if let Some(children) = self.children.get(&start_index) {
+            for node_index in children {
+                self.dump_at_internal(*node_index, depth + 1, widgets);
+            }
+        }
+    }
 }
 
 pub struct DownwardIterator<'a> {


### PR DESCRIPTION
## Objective

Debugging a `Tree` can be difficult due to how it's structured (two different `HashMap` collections for parents and children) and because all it contains are `Index` objects.

<details>
<summary>Output of <code>println!("{:#?}", tree)</code></summary>

```
Tree {
    children: {
        Index {
            index: 0,
            generation: 0,
        }: [
            Index {
                index: 16,
                generation: 0,
            },
            Index {
                index: 54,
                generation: 0,
            },
        ],
        Index {
            index: 21,
            generation: 0,
        }: [
            Index {
                index: 26,
                generation: 0,
            },
        ],
        Index {
            index: 16,
            generation: 0,
        }: [
            Index {
                index: 21,
                generation: 0,
            },
            Index {
                index: 30,
                generation: 0,
            },
            Index {
                index: 39,
                generation: 0,
            },
            Index {
                index: 47,
                generation: 0,
            },
        ],
        Index {
            index: 30,
            generation: 0,
        }: [
            Index {
                index: 35,
                generation: 0,
            },
        ],
        Index {
            index: 39,
            generation: 0,
        }: [
            Index {
                index: 44,
                generation: 0,
            },
        ],
    },
    parents: {
        Index {
            index: 16,
            generation: 0,
        }: Index {
            index: 0,
            generation: 0,
        },
        Index {
            index: 44,
            generation: 0,
        }: Index {
            index: 39,
            generation: 0,
        },
        Index {
            index: 47,
            generation: 0,
        }: Index {
            index: 16,
            generation: 0,
        },
        Index {
            index: 39,
            generation: 0,
        }: Index {
            index: 16,
            generation: 0,
        },
        Index {
            index: 35,
            generation: 0,
        }: Index {
            index: 30,
            generation: 0,
        },
        Index {
            index: 21,
            generation: 0,
        }: Index {
            index: 16,
            generation: 0,
        },
        Index {
            index: 30,
            generation: 0,
        }: Index {
            index: 16,
            generation: 0,
        },
        Index {
            index: 54,
            generation: 0,
        }: Index {
            index: 0,
            generation: 0,
        },
        Index {
            index: 26,
            generation: 0,
        }: Index {
            index: 21,
            generation: 0,
        },
    },
    root_node: Some(
        Index {
            index: 0,
            generation: 0,
        },
    ),
}
```

</details>

## Solution

Added a method to dump the contents of a tree,— (optionally) with widget metadata,— to the console. This recurses down the hierarchy, printing out each node along the way, resulting in something like:

```
App [0:0]
	TabBar [16:0]
		Background [21:0]
			Background [26:0]
		Background [30:0]
			Background [35:0]
		Background [39:0]
			Background [44:0]
		Element [47:0]
	TextBox [54:0]
```

with widget data. And with no widget data provided:

```
 [0:0]
	 [16:0]
		 [21:0]
			 [26:0]
		 [30:0]
			 [35:0]
		 [39:0]
			 [44:0]
		 [47:0]
	 [54:0]
```

This is done using the `Tree::dump` method (or `Tree::dump_at` for printing sections of the tree).

### Alternatives/Considerations

One thing we could do instead is return a string instead of directly printing to the console. I don't know how useful that is, so I opted to just print it out straight away. We could also pass a formatter to have it write to (that might be better so we can print to log files if needed).

Another consideration is the usage of tabs over some other string to represent depth. I chose tabs because (1) whitespace reduces visual noise and (2) its width can be configured. But if there's a preference for something else, we could definitely use that.

Lastly, we can also consider whether to keep this in `Tree` or not. If not, we could move it out as a pure utility function, or we could even create a separate `TreeFormatter` struct to handle formatting and outputting (the latter also allows us to add more optional and configurable settings).