### PR TITLE
Draggable Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Widget's can create their own state and will re-render when that state changes.
 fn Counter(context: &mut KayakContext) {
     let (count, set_count, ..) = use_state!(0i32);
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => set_count(count + 1),
+        EventType::Click(..) => set_count(count + 1),
         _ => {}
     });
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -31,7 +31,7 @@ fn Counter(context: &mut KayakContext) {
 
     let (count, set_count, ..) = use_state!(0i32);
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => set_count(count + 1),
+        EventType::Click(..) =>  set_count(count + 1),
         _ => {}
     });
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -31,7 +31,7 @@ fn Counter(context: &mut KayakContext) {
 
     let (count, set_count, ..) = use_state!(0i32);
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  set_count(count + 1),
+        EventType::Click(..) => set_count(count + 1),
         _ => {}
     });
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -37,7 +37,7 @@ fn Counter(context: &mut KayakContext) {
 
     rsx! {
         <>
-            <Window position={(50.0, 50.0)} size={(300.0, 300.0)} title={"Counter Example".to_string()}>
+            <Window draggable={true} position={(50.0, 50.0)} size={(300.0, 300.0)} title={"Counter Example".to_string()}>
                 <Text styles={Some(text_styles)} size={32.0} content={format!("Current Count: {}", count).to_string()}>{}</Text>
                 <Button on_event={Some(on_event)}>
                     <Text styles={Some(button_text_styles)} line_height={Some(40.0)} size={24.0} content={"Count!".to_string()}>{}</Text>

--- a/examples/fold.rs
+++ b/examples/fold.rs
@@ -63,12 +63,12 @@ fn FolderTree(context: &mut KayakContext) {
     let (is_b_open, set_b_open, ..) = use_state!(false);
     let set_close_b = set_b_open.clone();
     let close_b = Some(OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  set_close_b(false),
+        EventType::Click(..) => set_close_b(false),
         _ => {}
     }));
     let set_open_b = set_b_open.clone();
     let open_b = Some(OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  set_open_b(true),
+        EventType::Click(..) => set_open_b(true),
         _ => {}
     }));
 

--- a/examples/fold.rs
+++ b/examples/fold.rs
@@ -63,12 +63,12 @@ fn FolderTree(context: &mut KayakContext) {
     let (is_b_open, set_b_open, ..) = use_state!(false);
     let set_close_b = set_b_open.clone();
     let close_b = Some(OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => set_close_b(false),
+        EventType::Click(..) =>  set_close_b(false),
         _ => {}
     }));
     let set_open_b = set_b_open.clone();
     let open_b = Some(OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => set_open_b(true),
+        EventType::Click(..) =>  set_open_b(true),
         _ => {}
     }));
 

--- a/examples/full_ui.rs
+++ b/examples/full_ui.rs
@@ -53,10 +53,10 @@ fn BlueButton(context: KayakContext, children: Children, styles: Option<Style>) 
 
     let cloned_current_button_handle = current_button_handle.clone();
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::MouseIn => {
+        EventType::MouseIn(..) => {
             cloned_current_button_handle.set(blue_button_hover_handle);
         }
-        EventType::MouseOut => {
+        EventType::MouseOut(..) => {
             cloned_current_button_handle.set(blue_button_handle);
         }
         _ => (),

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -39,7 +39,7 @@ fn StateCounter() {
     // both implement `Copy`. For other types, you may have to clone the state to pass it into a closure like this.
     // (You can also clone the setter as well if you need to use it in multiple places.)
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  set_count(count + 1),
+        EventType::Click(..) => set_count(count + 1),
         _ => {}
     });
 
@@ -64,7 +64,7 @@ fn EffectCounter() {
     // the third field in the tuple returned from the `use_state` macro.
     let (count, set_count, raw_count) = use_state!(0);
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  set_count(count + 1),
+        EventType::Click(..) => set_count(count + 1),
         _ => {}
     });
 

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -39,7 +39,7 @@ fn StateCounter() {
     // both implement `Copy`. For other types, you may have to clone the state to pass it into a closure like this.
     // (You can also clone the setter as well if you need to use it in multiple places.)
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => set_count(count + 1),
+        EventType::Click(..) =>  set_count(count + 1),
         _ => {}
     });
 
@@ -64,7 +64,7 @@ fn EffectCounter() {
     // the third field in the tuple returned from the `use_state` macro.
     let (count, set_count, raw_count) = use_state!(0);
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => set_count(count + 1),
+        EventType::Click(..) =>  set_count(count + 1),
         _ => {}
     });
 

--- a/examples/if.rs
+++ b/examples/if.rs
@@ -24,7 +24,7 @@ fn Removal(context: &mut KayakContext) {
     let is_visible = context.create_state(true).unwrap();
     let cloned_is_visible = is_visible.clone();
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => {
+        EventType::Click(..) =>  {
             cloned_is_visible.set(!cloned_is_visible.get());
         }
         _ => {}

--- a/examples/if.rs
+++ b/examples/if.rs
@@ -24,7 +24,7 @@ fn Removal(context: &mut KayakContext) {
     let is_visible = context.create_state(true).unwrap();
     let cloned_is_visible = is_visible.clone();
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  {
+        EventType::Click(..) => {
             cloned_is_visible.set(!cloned_is_visible.get());
         }
         _ => {}

--- a/examples/provider.rs
+++ b/examples/provider.rs
@@ -89,7 +89,7 @@ fn ThemeButton(context: &mut KayakContext, theme: Theme) {
 
     let theme_clone = Arc::new(theme);
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  {
+        EventType::Click(..) => {
             // Update the shared state
             // This will cause the ThemeProvider to re-render along with all of the other consumers
             consumer.set((*theme_clone).clone());

--- a/examples/provider.rs
+++ b/examples/provider.rs
@@ -89,7 +89,7 @@ fn ThemeButton(context: &mut KayakContext, theme: Theme) {
 
     let theme_clone = Arc::new(theme);
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => {
+        EventType::Click(..) =>  {
             // Update the shared state
             // This will cause the ThemeProvider to re-render along with all of the other consumers
             consumer.set((*theme_clone).clone());

--- a/examples/tabs/tab.rs
+++ b/examples/tabs/tab.rs
@@ -30,14 +30,14 @@ pub fn Tab(context: &mut KayakContext, content: String, selected: bool) {
     };
 
     let event_handler = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Hover => {
+        EventType::Hover(..) => {
             if selected {
                 set_hover_state(TabHoverState::Active);
             } else {
                 set_hover_state(TabHoverState::Inactive);
             }
         }
-        EventType::MouseOut => {
+        EventType::MouseOut(..) => {
             set_hover_state(TabHoverState::None);
         }
         EventType::Focus => {

--- a/examples/tabs/tab_bar.rs
+++ b/examples/tabs/tab_bar.rs
@@ -24,7 +24,7 @@ pub fn TabBar(
         let on_select = on_select_tab.clone();
         let tab_event_handler = OnEvent::new(move |_, event| {
             match event.event_type {
-                EventType::Click => {
+                EventType::Click(..) =>  {
                     on_select.call(index);
                 }
                 EventType::KeyDown(evt) => {

--- a/examples/todo/add_button.rs
+++ b/examples/todo/add_button.rs
@@ -29,10 +29,10 @@ pub fn AddButton(children: Children, styles: Option<Style>) {
     });
 
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::MouseIn => {
+        EventType::MouseIn(..) => {
             set_color(Color::new(0.0791, 0.0998, 0.201, 1.0));
         }
-        EventType::MouseOut => {
+        EventType::MouseOut(..) => {
             set_color(Color::new(0.0781, 0.0898, 0.101, 1.0));
         }
         _ => {}

--- a/examples/todo/card.rs
+++ b/examples/todo/card.rs
@@ -24,7 +24,7 @@ pub fn Card(card_id: usize, name: String, on_delete: Handler<usize>) {
 
     let on_delete = on_delete.clone();
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => {
+        EventType::Click(..) => {
             on_delete.call(card_id);
         }
         _ => (),

--- a/examples/todo/delete_button.rs
+++ b/examples/todo/delete_button.rs
@@ -29,10 +29,10 @@ pub fn DeleteButton(children: Children, styles: Option<Style>) {
     });
 
     let on_event = OnEvent::new(move |_, event| match event.event_type {
-        EventType::MouseIn => {
+        EventType::MouseIn(..) => {
             set_color(Color::new(0.0791, 0.0998, 0.201, 1.0));
         }
-        EventType::MouseOut => {
+        EventType::MouseOut(..) => {
             set_color(Color::new(0.0781, 0.0898, 0.101, 1.0));
         }
         _ => {}

--- a/examples/todo/todo.rs
+++ b/examples/todo/todo.rs
@@ -61,7 +61,7 @@ fn TodoApp() {
     let mut todos_cloned = todos.clone();
     let cloned_set_todos = set_todos.clone();
     let add_events = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => {
+        EventType::Click(..) => {
             if !new_todo_value_cloned.is_empty() {
                 todos_cloned.push(Todo {
                     name: new_todo_value_cloned.clone(),

--- a/examples/world_interaction.rs
+++ b/examples/world_interaction.rs
@@ -106,7 +106,7 @@ fn ControlPanel() {
 
     rsx! {
         <>
-            <Window position={(0.0, 570.0)} size={(1270.0, 150.0)} title={"Square Mover: The Game".to_string()}>
+            <Window draggable={true} position={(0.0, 570.0)} size={(1270.0, 150.0)} title={"Square Mover: The Game".to_string()}>
                 <Text size={13.0} content={"You can check if the cursor is over the UI or on a focusable widget using the BevyContext resource.".to_string()} styles={Some(text_styles)} />
                 <Button on_event={Some(on_change_color)} styles={Some(button_styles)}>
                     <Text size={16.0} content={"Change Tile Color".to_string()} />

--- a/examples/world_interaction.rs
+++ b/examples/world_interaction.rs
@@ -106,7 +106,7 @@ fn ControlPanel() {
 
     rsx! {
         <>
-            <Window draggable={true} position={(0.0, 570.0)} size={(1270.0, 150.0)} title={"Square Mover: The Game".to_string()}>
+            <Window draggable={true} position={(50.0, 50.0)} size={(300.0, 150.0)} title={"Square Mover: The Game".to_string()}>
                 <Text size={13.0} content={"You can check if the cursor is over the UI or on a focusable widget using the BevyContext resource.".to_string()} styles={Some(text_styles)} />
                 <Button on_event={Some(on_change_color)} styles={Some(button_styles)}>
                     <Text size={16.0} content={"Change Tile Color".to_string()} />

--- a/examples/world_interaction.rs
+++ b/examples/world_interaction.rs
@@ -97,7 +97,7 @@ fn ControlPanel() {
     }
 
     let on_change_color = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => {
+        EventType::Click(..) => {
             // Cycle the color
             set_color_index((color_index + 1) % COLORS.len());
         }

--- a/kayak_core/src/context.rs
+++ b/kayak_core/src/context.rs
@@ -26,7 +26,7 @@ pub struct KayakContext {
     /// Maps the type of the data to a mapping of the provider node's ID to the state data
     widget_providers: HashMap<std::any::TypeId, HashMap<crate::Index, resources::Resources>>,
     widget_state_lifetimes:
-        HashMap<crate::Index, HashMap<crate::flo_binding::Uuid, Box<dyn crate::Releasable>>>,
+    HashMap<crate::Index, HashMap<crate::flo_binding::Uuid, Box<dyn crate::Releasable>>>,
     widget_states: HashMap<crate::Index, resources::Resources>,
 }
 
@@ -423,7 +423,7 @@ impl KayakContext {
     pub fn process_events(&mut self, input_events: Vec<InputEvent>) {
         let mut dispatcher = self.event_dispatcher.to_owned();
         dispatcher.process_events(input_events, self);
-        self.event_dispatcher = dispatcher;
+        self.event_dispatcher.merge(dispatcher);
     }
 
     #[allow(dead_code)]
@@ -460,8 +460,8 @@ impl KayakContext {
 
     #[cfg(feature = "bevy_renderer")]
     pub fn query_world<T: bevy::ecs::system::SystemParam, F, R>(&mut self, mut f: F) -> R
-    where
-        F: FnMut(<T::Fetch as bevy::ecs::system::SystemParamFetch<'_, '_>>::Item) -> R,
+        where
+            F: FnMut(<T::Fetch as bevy::ecs::system::SystemParamFetch<'_, '_>>::Item) -> R,
     {
         let mut world = self.get_global_state::<bevy::prelude::World>().unwrap();
         let mut system_state = bevy::ecs::system::SystemState::<T>::new(&mut world);
@@ -532,5 +532,33 @@ impl KayakContext {
     /// the widget bounds (as long as it started within it).
     pub fn has_cursor(&self) -> bool {
         self.event_dispatcher.has_cursor()
+    }
+
+    /// Captures all cursor events and instead makes the given index the target
+    pub fn capture_cursor(&mut self, index: Index) -> Option<Index> {
+        self.event_dispatcher.capture_cursor(index)
+    }
+
+    /// Releases the captured cursor
+    ///
+    /// Returns true if successful.
+    ///
+    /// This will only release the cursor if the given index matches the current captor. This
+    /// prevents other widgets from accidentally releasing against the will of the original captor.
+    ///
+    /// This check can be side-stepped if necessary by calling [`force_release_cursor`](Self::force_release_cursor)
+    /// instead (or by calling this method with the correct index).
+    pub fn release_cursor(&mut self, index: Index) -> bool {
+        self.event_dispatcher.release_cursor(index)
+    }
+
+    /// Releases the captured cursor
+    ///
+    /// Returns the index of the previous captor.
+    ///
+    /// This will force the release, regardless of which widget has called it. To safely release,
+    /// use the standard [`release_cursor`](Self::release_cursor) method instead.
+    pub fn force_release_cursor(&mut self) -> Option<Index> {
+        self.event_dispatcher.force_release_cursor()
     }
 }

--- a/kayak_core/src/context.rs
+++ b/kayak_core/src/context.rs
@@ -26,7 +26,7 @@ pub struct KayakContext {
     /// Maps the type of the data to a mapping of the provider node's ID to the state data
     widget_providers: HashMap<std::any::TypeId, HashMap<crate::Index, resources::Resources>>,
     widget_state_lifetimes:
-    HashMap<crate::Index, HashMap<crate::flo_binding::Uuid, Box<dyn crate::Releasable>>>,
+        HashMap<crate::Index, HashMap<crate::flo_binding::Uuid, Box<dyn crate::Releasable>>>,
     widget_states: HashMap<crate::Index, resources::Resources>,
 }
 
@@ -460,8 +460,8 @@ impl KayakContext {
 
     #[cfg(feature = "bevy_renderer")]
     pub fn query_world<T: bevy::ecs::system::SystemParam, F, R>(&mut self, mut f: F) -> R
-        where
-            F: FnMut(<T::Fetch as bevy::ecs::system::SystemParamFetch<'_, '_>>::Item) -> R,
+    where
+        F: FnMut(<T::Fetch as bevy::ecs::system::SystemParamFetch<'_, '_>>::Item) -> R,
     {
         let mut world = self.get_global_state::<bevy::prelude::World>().unwrap();
         let mut system_state = bevy::ecs::system::SystemState::<T>::new(&mut world);

--- a/kayak_core/src/cursor.rs
+++ b/kayak_core/src/cursor.rs
@@ -16,3 +16,11 @@ impl Default for PointerEvents {
         Self::All
     }
 }
+
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct CursorEvent {
+    pub(crate) pressed: bool,
+    pub(crate) just_pressed: bool,
+    pub(crate) just_released: bool,
+    pub(crate) position: (f32, f32)
+}

--- a/kayak_core/src/cursor.rs
+++ b/kayak_core/src/cursor.rs
@@ -19,8 +19,8 @@ impl Default for PointerEvents {
 
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct CursorEvent {
-    pub(crate) pressed: bool,
-    pub(crate) just_pressed: bool,
-    pub(crate) just_released: bool,
-    pub(crate) position: (f32, f32)
+    pub pressed: bool,
+    pub just_pressed: bool,
+    pub just_released: bool,
+    pub position: (f32, f32)
 }

--- a/kayak_core/src/cursor.rs
+++ b/kayak_core/src/cursor.rs
@@ -22,5 +22,5 @@ pub struct CursorEvent {
     pub pressed: bool,
     pub just_pressed: bool,
     pub just_released: bool,
-    pub position: (f32, f32)
+    pub position: (f32, f32),
 }

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -1,4 +1,6 @@
+use derivative::Derivative;
 use crate::{Index, KeyboardEvent};
+use crate::cursor::CursorEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event {
@@ -19,7 +21,7 @@ impl Default for Event {
         Self {
             target: Default::default(),
             current_target: Default::default(),
-            event_type: EventType::Click,
+            event_type: EventType::Click(CursorEvent::default()),
             should_propagate: true,
             default_prevented: false,
         }
@@ -62,19 +64,52 @@ impl Event {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Derivative)]
+#[derivative(PartialEq, Hash, Eq)]
 pub enum EventType {
-    Click,
-    Hover,
-    MouseIn,
-    MouseOut,
-    MouseDown,
-    MouseUp,
+    Click(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        CursorEvent
+    ),
+    Hover(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        CursorEvent
+    ),
+    MouseIn(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        CursorEvent
+    ),
+    MouseOut(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        CursorEvent
+    ),
+    MouseDown(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        CursorEvent
+    ),
+    MouseUp(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        CursorEvent
+    ),
     Focus,
     Blur,
     CharInput { c: char },
-    KeyUp(KeyboardEvent),
-    KeyDown(KeyboardEvent),
+    KeyUp(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        KeyboardEvent
+    ),
+    KeyDown(
+        #[derivative(PartialEq = "ignore")]
+        #[derivative(Hash = "ignore")]
+        KeyboardEvent
+    ),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -92,16 +127,16 @@ impl EventType {
     pub fn propagates(&self) -> bool {
         match self {
             // Propagates
-            Self::Hover => true,
-            Self::Click => true,
-            Self::MouseDown => true,
-            Self::MouseUp => true,
+            Self::Hover(..) => true,
+            Self::Click(..) => true,
+            Self::MouseDown(..) => true,
+            Self::MouseUp(..) => true,
             Self::CharInput { .. } => true,
             Self::KeyUp(..) => true,
             Self::KeyDown(..) => true,
             // Doesn't Propagate
-            Self::MouseIn => false,
-            Self::MouseOut => false,
+            Self::MouseIn(..) => false,
+            Self::MouseOut(..) => false,
             Self::Focus => false,
             Self::Blur => false,
         }
@@ -111,12 +146,12 @@ impl EventType {
     pub fn event_category(&self) -> EventCategory {
         match self {
             // Mouse
-            Self::Hover => EventCategory::Mouse,
-            Self::Click => EventCategory::Mouse,
-            Self::MouseDown => EventCategory::Mouse,
-            Self::MouseUp => EventCategory::Mouse,
-            Self::MouseIn => EventCategory::Mouse,
-            Self::MouseOut => EventCategory::Mouse,
+            Self::Hover(..) => EventCategory::Mouse,
+            Self::Click(..) => EventCategory::Mouse,
+            Self::MouseDown(..) => EventCategory::Mouse,
+            Self::MouseUp(..) => EventCategory::Mouse,
+            Self::MouseIn(..) => EventCategory::Mouse,
+            Self::MouseOut(..) => EventCategory::Mouse,
             // Keyboard
             Self::CharInput { .. } => EventCategory::Keyboard,
             Self::KeyUp(..) => EventCategory::Keyboard,

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -1,5 +1,5 @@
-use crate::{Index, KeyboardEvent};
 use crate::cursor::CursorEvent;
+use crate::{Index, KeyboardEvent};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event {

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -1,4 +1,3 @@
-use derivative::Derivative;
 use crate::{Index, KeyboardEvent};
 use crate::cursor::CursorEvent;
 
@@ -64,52 +63,33 @@ impl Event {
     }
 }
 
-#[derive(Debug, Clone, Copy, Derivative)]
-#[derivative(PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub enum EventType {
-    Click(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        CursorEvent
-    ),
-    Hover(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        CursorEvent
-    ),
-    MouseIn(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        CursorEvent
-    ),
-    MouseOut(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        CursorEvent
-    ),
-    MouseDown(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        CursorEvent
-    ),
-    MouseUp(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        CursorEvent
-    ),
+    Click(CursorEvent),
+    Hover(CursorEvent),
+    MouseIn(CursorEvent),
+    MouseOut(CursorEvent),
+    MouseDown(CursorEvent),
+    MouseUp(CursorEvent),
     Focus,
     Blur,
     CharInput { c: char },
-    KeyUp(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        KeyboardEvent
-    ),
-    KeyDown(
-        #[derivative(PartialEq = "ignore")]
-        #[derivative(Hash = "ignore")]
-        KeyboardEvent
-    ),
+    KeyUp(KeyboardEvent),
+    KeyDown(KeyboardEvent),
+}
+
+impl Eq for EventType {}
+
+impl PartialEq for EventType {
+    fn eq(&self, _other: &Self) -> bool {
+        matches!(self, _other)
+    }
+}
+
+impl std::hash::Hash for EventType {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&std::mem::discriminant(self), state);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/kayak_core/src/event.rs
+++ b/kayak_core/src/event.rs
@@ -63,6 +63,11 @@ impl Event {
     }
 }
 
+/// The type of event
+///
+/// __Note:__ This type implements `PartialEq` and `Hash` in a way that only considers the variant itself,
+/// not the underlying data. If full comparisons are needed, they should be done with the inner data or
+/// with a custom wrapper.
 #[derive(Debug, Clone, Copy)]
 pub enum EventType {
     Click(CursorEvent),

--- a/kayak_core/src/event_dispatcher.rs
+++ b/kayak_core/src/event_dispatcher.rs
@@ -1,5 +1,6 @@
 use crate::flo_binding::{Binding, MutableBound};
 
+use crate::cursor::CursorEvent;
 use crate::layout_cache::Rect;
 use crate::render_command::RenderCommand;
 use crate::widget_manager::WidgetManager;
@@ -8,7 +9,6 @@ use crate::{
     KeyboardModifiers, PointerEvents, Widget,
 };
 use std::collections::{HashMap, HashSet};
-use crate::cursor::CursorEvent;
 
 type EventMap = HashMap<Index, HashSet<EventType>>;
 type TreeNode = (
@@ -207,15 +207,27 @@ impl EventDispatcher {
             // Mouse is currently pressed for this node
             if self.is_mouse_pressed && events.contains(&EventType::MouseDown(Default::default())) {
                 // Make sure this event isn't removed while mouse is still held down
-                Self::insert_event(&mut next_events, index, EventType::MouseDown(Default::default()));
+                Self::insert_event(
+                    &mut next_events,
+                    index,
+                    EventType::MouseDown(Default::default()),
+                );
             }
 
             // Mouse is currently within this node
             if events.contains(&EventType::MouseIn(Default::default()))
-                && !Self::contains_event(&next_events, index, &EventType::MouseOut(Default::default()))
+                && !Self::contains_event(
+                    &next_events,
+                    index,
+                    &EventType::MouseOut(Default::default()),
+                )
             {
                 // Make sure this event isn't removed while mouse is still within node
-                Self::insert_event(&mut next_events, index, EventType::MouseIn(Default::default()));
+                Self::insert_event(
+                    &mut next_events,
+                    index,
+                    EventType::MouseIn(Default::default()),
+                );
             }
         }
 
@@ -398,7 +410,7 @@ impl EventDispatcher {
         tree_node: TreeNode,
         states: &mut HashMap<EventType, EventState>,
         widget_manager: &WidgetManager,
-        ignore_layout: bool
+        ignore_layout: bool,
     ) -> Vec<Event> {
         let mut event_stream = Vec::<Event>::new();
         let (node, depth) = tree_node;
@@ -435,7 +447,12 @@ impl EventDispatcher {
 
                     // Check for hover eligibility
                     if ignore_layout || is_contained {
-                        Self::update_state(states, (node, depth), layout, EventType::Hover(cursor_event));
+                        Self::update_state(
+                            states,
+                            (node, depth),
+                            layout,
+                            EventType::Hover(cursor_event),
+                        );
                     }
                 }
             }
@@ -470,9 +487,17 @@ impl EventDispatcher {
                         event_stream.push(Event::new(node, EventType::MouseUp(cursor_event)));
                         self.last_clicked.set(node);
 
-                        if Self::contains_event(&self.previous_events, &node, &EventType::MouseDown(cursor_event))
-                        {
-                            Self::update_state(states, (node, depth), layout, EventType::Click(cursor_event));
+                        if Self::contains_event(
+                            &self.previous_events,
+                            &node,
+                            &EventType::MouseDown(cursor_event),
+                        ) {
+                            Self::update_state(
+                                states,
+                                (node, depth),
+                                layout,
+                                EventType::Click(cursor_event),
+                            );
                         }
                     }
                 }

--- a/kayak_core/src/event_dispatcher.rs
+++ b/kayak_core/src/event_dispatcher.rs
@@ -404,6 +404,17 @@ impl EventDispatcher {
         event_stream
     }
 
+    /// Process the pointer-related events of an input event
+    ///
+    /// # Arguments
+    ///
+    /// * `input_event`: The input event
+    /// * `tree_node`: The current node to process
+    /// * `states`: The map of events to their current state (for selecting best fit)
+    /// * `widget_manager`: The widget manager
+    /// * `ignore_layout`: Whether to ignore layout (useful for handling captured events)
+    ///
+    /// returns: Vec<Event>
     fn process_pointer_events(
         &mut self,
         input_event: &InputEvent,

--- a/kayak_render_macros/src/lib.rs
+++ b/kayak_render_macros/src/lib.rs
@@ -137,7 +137,7 @@ pub fn dyn_partial_eq(_: TokenStream, input: TokenStream) -> TokenStream {
 /// let (count, set_count, ..) = use_state!(0);
 ///
 /// let on_event = OnEvent::new(move |_, event| match event.event_type {
-///         EventType::Click => {
+///         EventType::Click(..) => {
 ///             set_count(foo + 1);
 ///         }
 ///         _ => {}
@@ -215,7 +215,7 @@ pub fn use_state(initial_state: TokenStream) -> TokenStream {
 /// }, [count_state]);
 ///
 /// let on_event = OnEvent::new(move |_, event| match event.event_type {
-///         EventType::Click => {
+///         EventType::Click(..) => {
 ///             set_count(foo + 1);
 ///         }
 ///         _ => {}

--- a/src/widgets/fold.rs
+++ b/src/widgets/fold.rs
@@ -54,7 +54,7 @@ pub fn Fold(
     }
 
     let handler = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click(..) =>  {
+        EventType::Click(..) => {
             if open.is_none() {
                 // This is an internally-managed state
                 set_is_open(!is_open);

--- a/src/widgets/fold.rs
+++ b/src/widgets/fold.rs
@@ -54,7 +54,7 @@ pub fn Fold(
     }
 
     let handler = OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => {
+        EventType::Click(..) =>  {
             if open.is_none() {
                 // This is an internally-managed state
                 set_is_open(!is_open);

--- a/src/widgets/inspector.rs
+++ b/src/widgets/inspector.rs
@@ -72,7 +72,7 @@ pub fn Inspector() {
     }
 
     let handle_button_events = Some(OnEvent::new(move |_, event| match event.event_type {
-        EventType::Click => last_clicked.set(parent_id_move.unwrap()),
+        EventType::Click(..) => last_clicked.set(parent_id_move.unwrap()),
         _ => {}
     }));
 

--- a/src/widgets/tooltip.rs
+++ b/src/widgets/tooltip.rs
@@ -185,19 +185,19 @@ pub fn TooltipConsumer(
 
     let text = Arc::new(text);
     self.on_event = Some(OnEvent::new(move |ctx, event| match event.event_type {
-        EventType::MouseIn => {
+        EventType::MouseIn(..) => {
             let mut state = data.get();
             state.visible = true;
             state.text = (*text).clone();
             state.size = size;
             data.set(state);
         }
-        EventType::Hover => {
+        EventType::Hover(..) => {
             let mut state = data.get();
             state.anchor = anchor.unwrap_or(ctx.last_mouse_position());
             data.set(state);
         }
-        EventType::MouseOut => {
+        EventType::MouseOut(..) => {
             let mut state = data.get();
             // Set hidden only if the tooltip's text matches this consumer's
             // Otherwise, it likely got picked up by another widget and should be kept visible

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -1,9 +1,9 @@
 use crate::core::{
     color::Color,
     render_command::RenderCommand,
-    rsx, EventType, OnEvent, use_state,
+    rsx,
     styles::{PositionType, Style, StyleProp, Units},
-    widget, Children,
+    use_state, widget, Children, EventType, OnEvent,
 };
 
 use crate::widgets::{Background, Clip, Element, Text};
@@ -22,25 +22,23 @@ pub fn Window(
     let (pos, set_pos, ..) = use_state!(position);
 
     let drag_handler = if draggable {
-        Some(OnEvent::new(move |ctx, event|
-            match event.event_type {
-                EventType::MouseDown(data) => {
-                    ctx.capture_cursor(event.current_target);
-                    set_is_dragging(true);
-                    set_offset((pos.0 - data.position.0, pos.1 - data.position.1));
-                }
-                EventType::MouseUp(..) => {
-                    ctx.release_cursor(event.current_target);
-                    set_is_dragging(false);
-                }
-                EventType::Hover(data) => {
-                    if is_dragging {
-                        set_pos((offset.0 + data.position.0, offset.1 + data.position.1));
-                    }
-                }
-                _ => {}
+        Some(OnEvent::new(move |ctx, event| match event.event_type {
+            EventType::MouseDown(data) => {
+                ctx.capture_cursor(event.current_target);
+                set_is_dragging(true);
+                set_offset((pos.0 - data.position.0, pos.1 - data.position.1));
             }
-        ))
+            EventType::MouseUp(..) => {
+                ctx.release_cursor(event.current_target);
+                set_is_dragging(false);
+            }
+            EventType::Hover(data) => {
+                if is_dragging {
+                    set_pos((offset.0 + data.position.0, offset.1 + data.position.1));
+                }
+            }
+            _ => {}
+        }))
     } else {
         None
     };

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     color::Color,
     render_command::RenderCommand,
-    rsx,
+    rsx, EventType, OnEvent, use_state,
     styles::{PositionType, Style, StyleProp, Units},
     widget, Children,
 };
@@ -15,14 +15,43 @@ pub fn Window(
     position: (f32, f32),
     size: (f32, f32),
     title: String,
+    draggable: bool,
 ) {
+    let (is_dragging, set_is_dragging, ..) = use_state!(false);
+    let (offset, set_offset, ..) = use_state!((0.0, 0.0));
+    let (pos, set_pos, ..) = use_state!(position);
+
+    let drag_handler = if draggable {
+        Some(OnEvent::new(move |ctx, event|
+            match event.event_type {
+                EventType::MouseDown(data) => {
+                    ctx.capture_cursor(event.current_target);
+                    set_is_dragging(true);
+                    set_offset((pos.0 - data.position.0, pos.1 - data.position.1));
+                }
+                EventType::MouseUp(..) => {
+                    ctx.release_cursor(event.current_target);
+                    set_is_dragging(false);
+                }
+                EventType::Hover(data) => {
+                    if is_dragging {
+                        set_pos((offset.0 + data.position.0, offset.1 + data.position.1));
+                    }
+                }
+                _ => {}
+            }
+        ))
+    } else {
+        None
+    };
+
     *styles = Some(Style {
         background_color: StyleProp::Value(Color::new(0.125, 0.125, 0.125, 1.0)),
         border_radius: StyleProp::Value((5.0, 5.0, 5.0, 5.0)),
         render_command: StyleProp::Value(RenderCommand::Quad),
         position_type: StyleProp::Value(PositionType::SelfDirected),
-        left: StyleProp::Value(Units::Pixels(position.0)),
-        top: StyleProp::Value(Units::Pixels(position.1)),
+        left: StyleProp::Value(Units::Pixels(pos.0)),
+        top: StyleProp::Value(Units::Pixels(pos.1)),
         width: StyleProp::Value(Units::Pixels(size.0)),
         height: StyleProp::Value(Units::Pixels(size.1)),
         max_width: StyleProp::Value(Units::Pixels(size.0)),
@@ -72,7 +101,7 @@ pub fn Window(
     let title = title.clone();
     rsx! {
         <Clip styles={Some(clip_styles)}>
-            <Background styles={Some(title_background_styles)}>
+            <Background on_event={drag_handler} styles={Some(title_background_styles)}>
                 <Text styles={Some(title_text_styles)} size={16.0} content={title} />
             </Background>
             <Element styles={Some(content_styles)}>


### PR DESCRIPTION
## Objective

Add the ability to drag `Window` widgets around.

## Solution

Added the `draggable` prop to the `Window` widget, allowing it to be dragged from its title bar.

### Cursor Capturing

To add this functionality, I had to implement a way to capture all cursor events and pass them to the specified widget.

> See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture#example) for reference.

Therefore, I added the following methods (both on `EventDispatcher` and `KayakContext`):

* `capture_cursor(&mut self, index: Index)` - Captures all cursor events and sends them to the given widget instead
* `release_cursor(&mut self, index: Index) -> bool` - Releases the capture if the index matches
* `force_release_cursor(&mut self) -> Option<Index>` - Forcibly releases the capture, regardless of who owns it

## Additional Changes

Also added `CursorEvent` to all cursor-related variants in `EventType`. This was added to make accessing cursor related data right from the event.

```rust
pub struct CursorEvent {
  pub pressed: bool,
  pub just_pressed: bool,
  pub just_released: bool,
  pub position: (f32, f32),
}
```

This means all cursor event handlers needed to change from:

```rust
match event.event_type {
  EventType::Click => {/* ... */}
  EventType::MouseIn => {/* ... */}
  EventType::Hover => {/* ... */}
  _ => {}
}
```

to:

```rust
match event.event_type {
  EventType::Click(_) => {/* ... */}
  EventType::MouseIn(..) => {/* ... */}
  EventType::Hover(data) => {/* ... */}
  _ => {}
}
```

## Example

Added the `draggable` prop to the `counter` and `world_interaction` examples.

https://user-images.githubusercontent.com/49806985/150621137-d9dc3a11-47d6-4814-bc59-83700c44a977.mov