### PR TITLE
`OnEvent` now takes `KayakContextRef`

### DIFF
--- a/kayak_core/src/event_dispatcher.rs
+++ b/kayak_core/src/event_dispatcher.rs
@@ -4,10 +4,7 @@ use crate::cursor::CursorEvent;
 use crate::layout_cache::Rect;
 use crate::render_command::RenderCommand;
 use crate::widget_manager::WidgetManager;
-use crate::{
-    BoxedWidget, Event, EventType, Index, InputEvent, InputEventCategory, KayakContext, KeyCode,
-    KeyboardEvent, KeyboardModifiers, PointerEvents,
-};
+use crate::{BoxedWidget, Event, EventType, Index, InputEvent, InputEventCategory, KayakContext, KeyCode, KeyboardEvent, KeyboardModifiers, PointerEvents, KayakContextRef};
 use std::collections::{HashMap, HashSet};
 
 type EventMap = HashMap<Index, HashSet<EventType>>;
@@ -183,7 +180,8 @@ impl EventDispatcher {
 
                 // --- Call Event --- //
                 let mut target_widget = context.widget_manager.take(index);
-                target_widget.on_event(context, &mut node_event);
+                let mut ctx = KayakContextRef::new(context, Some(index));
+                target_widget.on_event(&mut ctx, &mut node_event);
                 context.widget_manager.repossess(target_widget);
 
                 event.default_prevented |= node_event.default_prevented;

--- a/kayak_core/src/event_dispatcher.rs
+++ b/kayak_core/src/event_dispatcher.rs
@@ -4,7 +4,10 @@ use crate::cursor::CursorEvent;
 use crate::layout_cache::Rect;
 use crate::render_command::RenderCommand;
 use crate::widget_manager::WidgetManager;
-use crate::{BoxedWidget, Event, EventType, Index, InputEvent, InputEventCategory, KayakContext, KeyCode, KeyboardEvent, KeyboardModifiers, PointerEvents, KayakContextRef};
+use crate::{
+    BoxedWidget, Event, EventType, Index, InputEvent, InputEventCategory, KayakContext,
+    KayakContextRef, KeyCode, KeyboardEvent, KeyboardModifiers, PointerEvents,
+};
 use std::collections::{HashMap, HashSet};
 
 type EventMap = HashMap<Index, HashSet<EventType>>;

--- a/kayak_core/src/on_event.rs
+++ b/kayak_core/src/on_event.rs
@@ -4,7 +4,9 @@ use std::sync::{Arc, RwLock};
 
 /// A container for a function that handles events
 #[derive(Clone)]
-pub struct OnEvent(Arc<RwLock<dyn FnMut(&mut KayakContextRef, &mut Event) + Send + Sync + 'static>>);
+pub struct OnEvent(
+    Arc<RwLock<dyn FnMut(&mut KayakContextRef, &mut Event) + Send + Sync + 'static>>,
+);
 
 impl OnEvent {
     /// Create a new event handler
@@ -12,7 +14,9 @@ impl OnEvent {
     /// The handler should be a closure that takes the following arguments:
     /// 1. The current context
     /// 2. The event
-    pub fn new<F: FnMut(&mut KayakContextRef, &mut Event) + Send + Sync + 'static>(f: F) -> OnEvent {
+    pub fn new<F: FnMut(&mut KayakContextRef, &mut Event) + Send + Sync + 'static>(
+        f: F,
+    ) -> OnEvent {
         OnEvent(Arc::new(RwLock::new(f)))
     }
 

--- a/kayak_core/src/on_event.rs
+++ b/kayak_core/src/on_event.rs
@@ -1,10 +1,10 @@
-use crate::{Event, KayakContext};
+use crate::{Event, KayakContextRef};
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLock};
 
 /// A container for a function that handles events
 #[derive(Clone)]
-pub struct OnEvent(Arc<RwLock<dyn FnMut(&mut KayakContext, &mut Event) + Send + Sync + 'static>>);
+pub struct OnEvent(Arc<RwLock<dyn FnMut(&mut KayakContextRef, &mut Event) + Send + Sync + 'static>>);
 
 impl OnEvent {
     /// Create a new event handler
@@ -12,14 +12,14 @@ impl OnEvent {
     /// The handler should be a closure that takes the following arguments:
     /// 1. The current context
     /// 2. The event
-    pub fn new<F: FnMut(&mut KayakContext, &mut Event) + Send + Sync + 'static>(f: F) -> OnEvent {
+    pub fn new<F: FnMut(&mut KayakContextRef, &mut Event) + Send + Sync + 'static>(f: F) -> OnEvent {
         OnEvent(Arc::new(RwLock::new(f)))
     }
 
     /// Call the event handler
     ///
     /// Returns true if the handler was successfully invoked.
-    pub fn try_call(&self, context: &mut KayakContext, event: &mut Event) -> bool {
+    pub fn try_call(&self, context: &mut KayakContextRef, event: &mut Event) -> bool {
         if let Ok(mut on_event) = self.0.write() {
             on_event(context, event);
             true

--- a/kayak_core/src/widget.rs
+++ b/kayak_core/src/widget.rs
@@ -2,7 +2,7 @@ use as_any::AsAny;
 use std::any::Any;
 
 use crate::{
-    context::KayakContext, context_ref::KayakContextRef, styles::Style, Children, Event, Index,
+    context_ref::KayakContextRef, styles::Style, Children, Event, Index,
     OnEvent,
 };
 
@@ -26,7 +26,7 @@ pub trait BaseWidget: SealedWidget + std::fmt::Debug + Send + Sync {
     fn get_props_mut(&mut self) -> &mut dyn WidgetProps;
     fn render(&mut self, context: &mut KayakContextRef);
     fn get_name(&self) -> &'static str;
-    fn on_event(&mut self, context: &mut KayakContext, event: &mut Event);
+    fn on_event(&mut self, context: &mut KayakContextRef, event: &mut Event);
 }
 
 pub trait Widget: std::fmt::Debug + Clone + Default + PartialEq + AsAny + Send + Sync {
@@ -65,7 +65,7 @@ pub trait Widget: std::fmt::Debug + Clone + Default + PartialEq + AsAny + Send +
     }
 
     /// Send an event to this widget
-    fn on_event(&mut self, context: &mut KayakContext, event: &mut Event) {
+    fn on_event(&mut self, context: &mut KayakContextRef, event: &mut Event) {
         if let Some(on_event) = self.get_props().get_on_event() {
             on_event.try_call(context, event);
         }
@@ -117,7 +117,7 @@ where
         Widget::get_name(self)
     }
 
-    fn on_event(&mut self, context: &mut KayakContext, event: &mut Event) {
+    fn on_event(&mut self, context: &mut KayakContextRef, event: &mut Event) {
         Widget::on_event(self, context, event);
     }
 }

--- a/kayak_core/src/widget.rs
+++ b/kayak_core/src/widget.rs
@@ -1,10 +1,7 @@
 use as_any::AsAny;
 use std::any::Any;
 
-use crate::{
-    context_ref::KayakContextRef, styles::Style, Children, Event, Index,
-    OnEvent,
-};
+use crate::{context_ref::KayakContextRef, styles::Style, Children, Event, Index, OnEvent};
 
 /// An internal trait that has a blanket implementation over all implementors of [Widget]
 ///


### PR DESCRIPTION
The `OnEvent` struct should take a `KayakContextRef` instead of `KayakContext` (as part of #56). Just replaced the usage of `KayakContext`.