### PR TITLE
Improved Styles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1849,6 +1849,7 @@ dependencies = [
  "desync",
  "flo_rope",
  "futures",
+ "indexmap",
  "kayak_font",
  "kayak_render_macros",
  "morphorm",

--- a/kayak_core/Cargo.toml
+++ b/kayak_core/Cargo.toml
@@ -20,3 +20,4 @@ kayak_render_macros = { path = "../kayak_render_macros" }
 morphorm = { git = "https://github.com/geom3trik/morphorm", rev = "1243152d4cebea46fd3e5098df26402c73acae91" }
 resources = "1.1"
 uuid = { version = "0.8", features = ["v4"] }
+indexmap = "1.8"

--- a/kayak_core/src/context.rs
+++ b/kayak_core/src/context.rs
@@ -379,7 +379,7 @@ impl KayakContext {
     pub fn render(&mut self) {
         let dirty_nodes: Vec<_> =
             if let Ok(mut dirty_nodes) = self.widget_manager.dirty_nodes.lock() {
-                dirty_nodes.drain().collect()
+                dirty_nodes.drain(..).collect()
             } else {
                 panic!("Couldn't get lock on dirty nodes!")
             };

--- a/kayak_core/src/node.rs
+++ b/kayak_core/src/node.rs
@@ -15,7 +15,7 @@ pub struct Node {
 impl Node {}
 
 pub struct NodeBuilder {
-    node: Node
+    node: Node,
 }
 
 impl NodeBuilder {
@@ -26,8 +26,8 @@ impl NodeBuilder {
                 id: Index::default(),
                 resolved_styles: Style::default(),
                 raw_styles: None,
-                z: 0.0
-            }
+                z: 0.0,
+            },
         }
     }
 
@@ -38,8 +38,8 @@ impl NodeBuilder {
                 id,
                 resolved_styles: styles,
                 raw_styles: None,
-                z: 0.0
-            }
+                z: 0.0,
+            },
         }
     }
 

--- a/kayak_core/src/node.rs
+++ b/kayak_core/src/node.rs
@@ -7,57 +7,60 @@ use crate::{
 pub struct Node {
     pub children: Vec<Index>,
     pub id: Index,
-    pub styles: Style,
+    pub resolved_styles: Style,
+    pub raw_styles: Option<Style>,
     pub z: f32,
 }
 
 impl Node {}
 
 pub struct NodeBuilder {
-    children: Vec<Index>,
-    id: Index,
-    styles: Style,
+    node: Node
 }
 
 impl NodeBuilder {
     pub fn empty() -> Self {
         Self {
-            children: Vec::new(),
-            id: Index::default(),
-            styles: Style::default(),
+            node: Node {
+                children: Vec::new(),
+                id: Index::default(),
+                resolved_styles: Style::default(),
+                raw_styles: None,
+                z: 0.0
+            }
         }
     }
 
     pub fn new(id: Index, styles: Style) -> Self {
         Self {
-            children: Vec::new(),
-            id,
-            styles,
+            node: Node {
+                children: Vec::new(),
+                id,
+                resolved_styles: styles,
+                raw_styles: None,
+                z: 0.0
+            }
         }
     }
 
     pub fn with_id(mut self, id: Index) -> Self {
-        self.id = id;
+        self.node.id = id;
         self
     }
 
     pub fn with_children(mut self, children: Vec<Index>) -> Self {
-        self.children.extend(children);
+        self.node.children.extend(children);
         self
     }
 
-    pub fn with_styles(mut self, styles: Style) -> Self {
-        self.styles = styles;
+    pub fn with_styles(mut self, resolved_styles: Style, raw_styles: Option<Style>) -> Self {
+        self.node.resolved_styles = resolved_styles;
+        self.node.raw_styles = raw_styles;
         self
     }
 
     pub fn build(self) -> Node {
-        Node {
-            children: self.children,
-            id: self.id,
-            styles: self.styles,
-            z: 0.0,
-        }
+        self.node
     }
 }
 
@@ -67,7 +70,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn layout_type(&self, store: &'_ Self::Data) -> Option<morphorm::LayoutType> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.layout_type {
+                return match node.resolved_styles.layout_type {
                     StyleProp::Default => Some(morphorm::LayoutType::default()),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::LayoutType::default()),
@@ -80,7 +83,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn position_type(&self, store: &'_ Self::Data) -> Option<morphorm::PositionType> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.position_type {
+                return match node.resolved_styles.position_type {
                     StyleProp::Default => Some(morphorm::PositionType::default()),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::PositionType::default()),
@@ -93,7 +96,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn width(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.width {
+                return match node.resolved_styles.width {
                     StyleProp::Default => Some(morphorm::Units::Stretch(1.0)),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Stretch(1.0)),
@@ -106,7 +109,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn height(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.height {
+                return match node.resolved_styles.height {
                     StyleProp::Default => Some(morphorm::Units::Stretch(1.0)),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Stretch(1.0)),
@@ -119,7 +122,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn min_width(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.min_width {
+                return match node.resolved_styles.min_width {
                     StyleProp::Default => Some(morphorm::Units::Pixels(0.0)),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -132,7 +135,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn min_height(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.min_height {
+                return match node.resolved_styles.min_height {
                     StyleProp::Default => Some(morphorm::Units::Pixels(0.0)),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -145,7 +148,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn max_width(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.max_width {
+                return match node.resolved_styles.max_width {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -158,7 +161,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn max_height(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.max_height {
+                return match node.resolved_styles.max_height {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -171,7 +174,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn left(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.left {
+                return match node.resolved_styles.left {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -184,7 +187,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn right(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.right {
+                return match node.resolved_styles.right {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -197,7 +200,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn top(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.top {
+                return match node.resolved_styles.top {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -210,7 +213,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn bottom(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.bottom {
+                return match node.resolved_styles.bottom {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -255,7 +258,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn child_left(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.padding_left {
+                return match node.resolved_styles.padding_left {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -268,7 +271,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn child_right(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.padding_right {
+                return match node.resolved_styles.padding_right {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -281,7 +284,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn child_top(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.padding_top {
+                return match node.resolved_styles.padding_top {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -294,7 +297,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn child_bottom(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.padding_bottom {
+                return match node.resolved_styles.padding_bottom {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(prop),
                     _ => Some(morphorm::Units::Auto),
@@ -339,7 +342,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn border_left(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.border {
+                return match node.resolved_styles.border {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(morphorm::Units::Pixels(prop.3)),
                     _ => Some(morphorm::Units::Auto),
@@ -352,7 +355,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn border_right(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.border {
+                return match node.resolved_styles.border {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(morphorm::Units::Pixels(prop.1)),
                     _ => Some(morphorm::Units::Auto),
@@ -365,7 +368,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn border_top(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.border {
+                return match node.resolved_styles.border {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(morphorm::Units::Pixels(prop.0)),
                     _ => Some(morphorm::Units::Auto),
@@ -378,7 +381,7 @@ impl<'a> morphorm::Node<'a> for Index {
     fn border_bottom(&self, store: &'_ Self::Data) -> Option<morphorm::Units> {
         if let Some(node) = store.get(*self) {
             if let Some(node) = node {
-                return match node.styles.border {
+                return match node.resolved_styles.border {
                     StyleProp::Default => Some(morphorm::Units::Auto),
                     StyleProp::Value(prop) => Some(morphorm::Units::Pixels(prop.2)),
                     _ => Some(morphorm::Units::Auto),

--- a/kayak_core/src/styles.rs
+++ b/kayak_core/src/styles.rs
@@ -5,9 +5,18 @@ use crate::{color::Color, render_command::RenderCommand};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum StyleProp<T: Default + Clone> {
+    /// This prop is unset, meaning its actual value is not determined until style resolution,
+    /// wherein it will be set to the property's default value.
+    ///
+    /// When [merging](Style::merge) styles, only style properties of this type may be
+    /// overwritten.
     Unset,
+    /// Like [StyleProp::Unset], properties of this type wait until style resolution for their
+    /// actual values to be determined, wherein it will be set to the property's default value.
     Default,
+    /// Properties of this type inherit their value from their parent (determined at style resolution).
     Inherit,
+    /// Set a specific value for this property
     Value(T),
 }
 
@@ -31,6 +40,12 @@ impl<T> StyleProp<T>
             StyleProp::Value(value) => value.clone(),
             StyleProp::Inherit => panic!("All styles should be merged before resolving!"),
         }
+    }
+}
+
+impl<T: Default + Clone> From<T> for StyleProp<T> {
+    fn from(value: T) -> Self {
+        StyleProp::Value(value)
     }
 }
 

--- a/kayak_core/src/styles.rs
+++ b/kayak_core/src/styles.rs
@@ -21,8 +21,8 @@ pub enum StyleProp<T: Default + Clone> {
 }
 
 impl<T> Default for StyleProp<T>
-    where
-        T: Default + Clone,
+where
+    T: Default + Clone,
 {
     fn default() -> Self {
         Self::Unset
@@ -30,8 +30,8 @@ impl<T> Default for StyleProp<T>
 }
 
 impl<T> StyleProp<T>
-    where
-        T: Default + Clone,
+where
+    T: Default + Clone,
 {
     pub fn resolve(&self) -> T {
         match self {
@@ -48,7 +48,7 @@ impl<T> StyleProp<T>
     pub fn select<'a>(props: &'_ [&'a StyleProp<T>]) -> &'a Self {
         for prop in props {
             if !matches!(prop, StyleProp::Unset) {
-                return prop
+                return prop;
             }
         }
 

--- a/kayak_core/src/widget_manager.rs
+++ b/kayak_core/src/widget_manager.rs
@@ -1,7 +1,5 @@
-use std::{
-    sync::{Arc, Mutex},
-};
 use indexmap::IndexSet;
+use std::sync::{Arc, Mutex};
 
 use crate::layout_cache::Rect;
 use crate::{

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -38,24 +38,23 @@ impl WidgetProps for ButtonProps {
 
 #[widget]
 pub fn Button(props: ButtonProps) {
-    let base_styles = props.styles.clone().unwrap_or_default();
-    props.styles = Some(Style {
-        render_command: StyleProp::Value(RenderCommand::Quad),
-        border_radius: StyleProp::Value((5.0, 5.0, 5.0, 5.0)),
-        height: if base_styles.height == StyleProp::Default {
-            StyleProp::Value(Units::Pixels(45.0))
-        } else {
-            base_styles.height
-        },
-        background_color: if matches!(base_styles.background_color, StyleProp::Default) {
-            StyleProp::Value(Color::new(0.0781, 0.0898, 0.101, 1.0))
-        } else {
-            base_styles.background_color
-        },
-        padding_left: StyleProp::Value(Units::Stretch(1.0)),
-        padding_right: StyleProp::Value(Units::Stretch(1.0)),
-        ..base_styles
-    });
+    props.styles = Some(
+        Style::default()
+            .with_style(Style {
+                render_command: StyleProp::Value(RenderCommand::Quad),
+                ..Default::default()
+            })
+            .with_style(&props.styles)
+            .with_style(Style {
+                background_color: StyleProp::Value(Color::new(0.0781, 0.0898, 0.101, 1.0)),
+                border_radius: StyleProp::Value((5.0, 5.0, 5.0, 5.0)),
+                height: StyleProp::Value(Units::Pixels(45.0)),
+                padding_left: StyleProp::Value(Units::Stretch(1.0)),
+                padding_right: StyleProp::Value(Units::Stretch(1.0)),
+                ..Default::default()
+            })
+    );
+
     rsx! {
         <Fragment>
             {children}

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -52,7 +52,7 @@ pub fn Button(props: ButtonProps) {
                 padding_left: StyleProp::Value(Units::Stretch(1.0)),
                 padding_right: StyleProp::Value(Units::Stretch(1.0)),
                 ..Default::default()
-            })
+            }),
     );
 
     rsx! {

--- a/src/widgets/inspector.rs
+++ b/src/widgets/inspector.rs
@@ -55,9 +55,9 @@ pub fn Inspector(props: InspectorProps) {
             data.push(format!("Height: {}", layout.height));
             data.push(format!(
                 "RenderCommand: \n{:#?}",
-                node.styles.render_command
+                node.resolved_styles.render_command
             ));
-            data.push(format!("Height: \n{:#?}", node.styles.height));
+            data.push(format!("Height: \n{:#?}", node.resolved_styles.height));
 
             if let Some(parent_id) = context.get_valid_parent(last_clicked_value) {
                 parent_id_move = Some(parent_id);

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -88,7 +88,7 @@ pub fn TextBox(props: TextBoxProps) {
                 ..Default::default()
             })
             // Apply any prop-given styles
-            .with_style(props.styles)
+            .with_style(&props.styles)
             // If not set by props, apply these styles
             .with_style(Style {
                 top: Units::Pixels(0.0).into(),

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -95,7 +95,7 @@ pub fn TextBox(props: TextBoxProps) {
                 bottom: Units::Pixels(0.0).into(),
                 height: Units::Pixels(26.0).into(),
                 ..Default::default()
-            })
+            }),
     );
 
     let background_styles = Style {

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -1,7 +1,7 @@
 use crate::core::{
     render_command::RenderCommand,
     rsx,
-    styles::{Style, StyleProp, Units},
+    styles::{Style, Units},
     widget, Bound, Children, Color, EventType, MutableBound, OnEvent, WidgetProps,
 };
 use std::sync::{Arc, RwLock};
@@ -79,30 +79,32 @@ pub fn TextBox(props: TextBoxProps) {
         value,
         ..
     } = props.clone();
-    let current_styles = props.styles.clone().unwrap_or_default();
-    props.styles = Some(Style {
-        render_command: StyleProp::Value(RenderCommand::Layout),
-        height: StyleProp::Value(Units::Pixels(26.0)),
-        top: if matches!(current_styles.top, StyleProp::Value { .. }) {
-            current_styles.top.clone()
-        } else {
-            StyleProp::Value(Units::Pixels(0.0))
-        },
-        bottom: if matches!(current_styles.bottom, StyleProp::Value { .. }) {
-            current_styles.top.clone()
-        } else {
-            StyleProp::Value(Units::Pixels(0.0))
-        },
-        ..current_styles
-    });
+
+    props.styles = Some(
+        Style::default()
+            // Required styles
+            .with_style(Style {
+                render_command: RenderCommand::Layout.into(),
+                ..Default::default()
+            })
+            // Apply any prop-given styles
+            .with_style(props.styles)
+            // If not set by props, apply these styles
+            .with_style(Style {
+                top: Units::Pixels(0.0).into(),
+                bottom: Units::Pixels(0.0).into(),
+                height: Units::Pixels(26.0).into(),
+                ..Default::default()
+            })
+    );
 
     let background_styles = Style {
-        background_color: StyleProp::Value(Color::new(0.176, 0.196, 0.215, 1.0)),
-        border_radius: StyleProp::Value((5.0, 5.0, 5.0, 5.0)),
-        height: StyleProp::Value(Units::Pixels(26.0)),
-        padding_left: StyleProp::Value(Units::Pixels(5.0)),
-        padding_right: StyleProp::Value(Units::Pixels(5.0)),
-        ..props.styles.clone().unwrap_or_default()
+        background_color: Color::new(0.176, 0.196, 0.215, 1.0).into(),
+        border_radius: (5.0, 5.0, 5.0, 5.0).into(),
+        height: Units::Pixels(26.0).into(),
+        padding_left: Units::Pixels(5.0).into(),
+        padding_right: Units::Pixels(5.0).into(),
+        ..Default::default()
     };
 
     let has_focus = context.create_state(Focus(false)).unwrap();
@@ -138,14 +140,11 @@ pub fn TextBox(props: TextBoxProps) {
 
     let text_styles = if value.is_empty() || (has_focus.get().0 && value.is_empty()) {
         Style {
-            color: StyleProp::Value(Color::new(0.5, 0.5, 0.5, 1.0)),
+            color: Color::new(0.5, 0.5, 0.5, 1.0).into(),
             ..Style::default()
         }
     } else {
-        Style {
-            color: props.styles.clone().unwrap_or_default().color,
-            ..Style::default()
-        }
+        Style::default()
     };
 
     let value = if value.is_empty() {

--- a/src/widgets/tooltip.rs
+++ b/src/widgets/tooltip.rs
@@ -99,22 +99,25 @@ pub fn TooltipProvider(props: TooltipProviderProps) {
     } = tooltip.get();
     let tooltip_size = tooltip_size.unwrap_or((WIDTH, HEIGHT));
 
-    props.styles = Some(Style {
-        left: StyleProp::Value(Units::Pixels(position.0)),
-        top: StyleProp::Value(Units::Pixels(position.1)),
-        width: StyleProp::Value(Units::Pixels(size.0)),
-        height: StyleProp::Value(Units::Pixels(size.1)),
-        ..props.styles.clone().unwrap_or_default()
-    });
+    props.styles = Some(
+        Style::default()
+            .with_style(Style {
+                left: StyleProp::Value(Units::Pixels(position.0)),
+                top: StyleProp::Value(Units::Pixels(position.1)),
+                ..Default::default()
+            })
+            .with_style(&props.styles)
+            .with_style(Style {
+                width: StyleProp::Value(Units::Pixels(size.0)),
+                height: StyleProp::Value(Units::Pixels(size.1)),
+                ..Default::default()
+            })
+    );
 
     let base_styles = props.styles.clone().unwrap();
     let mut tooltip_styles = Style {
         position_type: StyleProp::Value(PositionType::SelfDirected),
-        background_color: if matches!(base_styles.background_color, StyleProp::Default) {
-            StyleProp::Value(Color::new(0.13, 0.15, 0.17, 0.85))
-        } else {
-            base_styles.background_color
-        },
+        background_color: StyleProp::select(&[&base_styles.background_color, &Color::new(0.13, 0.15, 0.17, 0.85).into()]).clone(),
         width: StyleProp::Value(Units::Pixels(tooltip_size.0)),
         height: StyleProp::Value(Units::Pixels(tooltip_size.1)),
         ..Style::default()
@@ -137,11 +140,7 @@ pub fn TooltipProvider(props: TooltipProviderProps) {
     let text_styles = Style {
         width: StyleProp::Value(Units::Pixels(tooltip_size.0)),
         height: StyleProp::Value(Units::Pixels(tooltip_size.1)),
-        color: if matches!(base_styles.color, StyleProp::Default) {
-            StyleProp::Value(Color::WHITE)
-        } else {
-            base_styles.color
-        },
+        color: StyleProp::select(&[&base_styles.color, &Color::WHITE.into()]).clone(),
         ..Style::default()
     };
 
@@ -196,12 +195,19 @@ pub fn TooltipConsumer(props: TooltipConsumerProps) {
     let TooltipConsumerProps {
         anchor, size, text, ..
     } = props.clone();
-    props.styles = Some(Style {
-        render_command: StyleProp::Value(RenderCommand::Clip),
-        width: StyleProp::Value(Units::Auto),
-        height: StyleProp::Value(Units::Auto),
-        ..props.styles.clone().unwrap_or_default()
-    });
+    props.styles = Some(
+        Style::default()
+            .with_style(Style {
+                render_command: StyleProp::Value(RenderCommand::Clip),
+                ..Default::default()
+            })
+            .with_style(&props.styles)
+            .with_style(Style {
+                width: StyleProp::Value(Units::Auto),
+                height: StyleProp::Value(Units::Auto),
+                ..Default::default()
+            })
+    );
 
     let data = context
         .create_consumer::<TooltipData>()

--- a/src/widgets/tooltip.rs
+++ b/src/widgets/tooltip.rs
@@ -111,13 +111,17 @@ pub fn TooltipProvider(props: TooltipProviderProps) {
                 width: StyleProp::Value(Units::Pixels(size.0)),
                 height: StyleProp::Value(Units::Pixels(size.1)),
                 ..Default::default()
-            })
+            }),
     );
 
     let base_styles = props.styles.clone().unwrap();
     let mut tooltip_styles = Style {
         position_type: StyleProp::Value(PositionType::SelfDirected),
-        background_color: StyleProp::select(&[&base_styles.background_color, &Color::new(0.13, 0.15, 0.17, 0.85).into()]).clone(),
+        background_color: StyleProp::select(&[
+            &base_styles.background_color,
+            &Color::new(0.13, 0.15, 0.17, 0.85).into(),
+        ])
+        .clone(),
         width: StyleProp::Value(Units::Pixels(tooltip_size.0)),
         height: StyleProp::Value(Units::Pixels(tooltip_size.1)),
         ..Style::default()
@@ -206,7 +210,7 @@ pub fn TooltipConsumer(props: TooltipConsumerProps) {
                 width: StyleProp::Value(Units::Auto),
                 height: StyleProp::Value(Units::Auto),
                 ..Default::default()
-            })
+            }),
     );
 
     let data = context


### PR DESCRIPTION
## Objective

This PR tackles two main issues:

1. `StyleProp::Inherit` was not working and attempting to resolve the style resulted in a panic
2. There was no easy way of merging styles

## Solution

### Inheritance

Solving inheritance was rather straightforward. We basically just needed a way to process nodes in the order they are added to the tree. Since we were using a `HashSet`, order was not guaranteed. The fix was to add the [`indexmap`](https://crates.io/crates/indexmap) crate as a dependency and use its drop-in replacement, `IndexSet`.

That pretty much did it surprisingly. The last change was to try and fetch the parent's resolved style before fetching their prop style (or default if not available).

I am not sure how robust of a solution this is, but initial tests show that it works (the Text in the Textbox widget, for example, can now inherit its color from the TextBox).

### Style Helpers

Managing styles can be difficult, especially if you're trying to pass and process many of them. This PR also addresses this by adding some helper methods.

First, though, it adds a new variant: `StyleProp::Unset`. This variant just means that a prop has not yet been set. This is distinct in `StyleProp::Default` in that the intention is to allow others to set its value (in some cases, we may actually want `StyleProp::Default`).

> This variant is also the new default value used in `StyleProp::default()` and `Style::default()`.

With this new variant, we can easily apply styles additively.

For example, instead of doing something like:

```rust
let styles = Style {
  // Required
  render_command: StyleProp::Value(RenderCommand::Layout),

  // Optional with defaults
  color: if matches!(props.styles.color, StyleProp::Unset) {
      props.styles.color.clone()
    } else {
      StyleProp::Value(Color::White)
    },
  width: if matches!(props.styles.width, StyleProp::Unset) {
      props.styles.width.clone()
    } else if matches!(other_styles.width, StyleProp::Unset) {
      other_styles.width.clone()
    } else {
      StyleProp::Value(Units::Pixels(25.0))
    },
  height: if matches!(props.styles.height, StyleProp::Unset) {
      props.styles.height.clone()
    } else {
      StyleProp::Value(Units::Pixels(50.0))
    },
  ..Default::default()
};
```

We can do this:

```rust
let styles = Style::default()
  // Our required styles
  .with_style(Style {
    render_command: StyleProp::Value(RenderCommand::Layout),
    ..Default::default()
  })

  // Styles from props
  .with_style(&props.styles)
  // Maybe some other styles
  .with_style(&other_styles)

  // Our defaults
  .with_style(Style {
    color: StyleProp::Value(Color::White),
    width: StyleProp::Value(Units::Pixels(25.0)),
    height: StyleProp::Value(Units::Pixels(50.0)),
    ..Default::default()
  });
```

> `with_style` can take any of the following: `Style`, `&Style`, `Option<Style>`, and `&Option<Style>`, making it very versatile.

Which is just a bit more readable (or at least more generic/concise).

There's also the `apply` method which does the same thing, but to a mutable self (no return).

#### Into StyleProp

This PR also adds a blanket `From` impl for `StyleProp`. This is just a quality of life thing to save us some keystrokes and imports:

```rust
let styles = Style::default()
  // Our required styles
  .with_style(Style {
    render_command: RenderCommand::Layout.into(),
    ..Default::default()
  })

  // Styles from props
  .with_style(&props.styles)
  // Maybe some other styles
  .with_style(&other_styles)

  // Our defaults
  .with_style(Style {
    color: Color::White.into(),
    width: Units::Pixels(25.0).into(),
    height: Units::Pixels(50.0).into(),
    ..Default::default()
  });
```

#### Select StyleProp

For smaller merges, we might not need to merge the entire `Style` object. Instead, we can do something similar on a smaller scale with `StyleProp::select(...)`:

```rust
let styles = Style {
  // Required
  render_command: StyleProp::Value(RenderCommand::Layout),
  // Optional with defaults
  color: StyleProp::select(&[
    &props.styles.color, 
    &other_styles.color, 
    &StyleProp::Value(Color::White)
  ]).clone(),
  ..Default::default()
};
```

#### `define_styles!`

The last change is an internal one. Basically, I made a macro (`define_styles!`) that can be used to generate the `Style` struct along with other implementation methods. The main purpose of this was just to reduce the number of errors caused by adding a new field but not updating all the methods to account for the change.

## Feedback

Any part of this PR can be renamed, removed, changed, etc. Let me know if there are any thoughts!