### PR TITLE
Empty props

### DIFF
--- a/examples/bevy_state.rs
+++ b/examples/bevy_state.rs
@@ -5,7 +5,7 @@ use bevy::{
 };
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
 use kayak_ui::core::{
-    render, rsx, widget, Event, EventType, Index, KayakContextRef, KeyCode, OnEvent, WidgetProps,
+    render, rsx, widget, Event, EventType, Index, KayakContextRef, KeyCode, OnEvent,
 };
 use kayak_ui::widgets::{App, Text};
 
@@ -36,11 +36,9 @@ fn handle_input(context: &mut KayakContextRef, event: &mut Event) {
         _ => {}
     };
 }
-#[derive(WidgetProps, Default, Debug, PartialEq, Clone)]
-pub struct StateSwitcherProps;
 
 #[widget]
-fn StateSwitcher(props: StateSwitcherProps) {
+fn StateSwitcher() {
     rsx! {
         <Text content={"Press space to switch states!".to_string()} size={32.0} />
     }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -7,15 +7,12 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{Style, StyleProp, Units},
-    use_state, widget, EventType, Index, OnEvent, WidgetProps,
+    use_state, widget, EventType, Index, OnEvent,
 };
 use kayak_ui::widgets::{App, Button, Text, Window};
 
-#[derive(WidgetProps, Default, Debug, PartialEq, Clone)]
-pub struct CounterProps {}
-
 #[widget]
-fn Counter(props: CounterProps) {
+fn Counter() {
     let text_styles = Style {
         bottom: StyleProp::Value(Units::Stretch(1.0)),
         left: StyleProp::Value(Units::Stretch(0.1)),

--- a/examples/fold.rs
+++ b/examples/fold.rs
@@ -9,13 +9,10 @@ use kayak_ui::{
     core::{
         render, rsx,
         styles::{Style, StyleProp, Units},
-        use_state, widget, Color, EventType, Handler, Index, OnEvent, WidgetProps,
+        use_state, widget, Color, EventType, Handler, Index, OnEvent,
     },
     widgets::{App, Background, Button, Fold, If, Text, Window},
 };
-
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct FolderTreeProps {}
 
 #[widget]
 fn FolderTree(props: FolderTreeProps) {

--- a/examples/global_counter.rs
+++ b/examples/global_counter.rs
@@ -4,17 +4,14 @@ use bevy::{
     DefaultPlugins,
 };
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
-use kayak_ui::core::{bind, render, rsx, widget, Binding, Bound, Index, MutableBound, WidgetProps};
+use kayak_ui::core::{bind, render, rsx, widget, Binding, Bound, Index, MutableBound};
 use kayak_ui::widgets::{App, Text, Window};
 
 #[derive(Clone, PartialEq)]
 struct GlobalCount(pub u32);
 
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct CounterProps {}
-
 #[widget]
-fn Counter(props: CounterProps) {
+fn Counter() {
     let global_count = context
         .query_world::<Res<Binding<GlobalCount>>, _, _>(move |global_count| global_count.clone());
 

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -16,12 +16,9 @@ use bevy::{
 };
 use kayak_ui::{
     bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle},
-    core::{render, rsx, use_effect, use_state, widget, EventType, Index, OnEvent, WidgetProps},
+    core::{render, rsx, use_effect, use_state, widget, EventType, Index, OnEvent},
     widgets::{App, Button, Text, Window},
 };
-
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct StateCounterProps {}
 
 /// A simple widget that tracks how many times a button is clicked using simple state data
 #[widget]
@@ -56,12 +53,9 @@ fn StateCounter(props: StateCounterProps) {
     }
 }
 
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct EffectCounterProps {}
-
 /// Another widget that tracks how many times a button is clicked using side-effects
 #[widget]
-fn EffectCounter(props: EffectCounterProps) {
+fn EffectCounter() {
     // In this widget, we're going to implement another counter, but this time using side-effects.
     // To put it very simply, a side-effect is when something happens in response to something else happening.
     // In our case, we want to create a side-effect that updates a counter when another state is updated.

--- a/examples/if.rs
+++ b/examples/if.rs
@@ -7,15 +7,12 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{Style, StyleProp, Units},
-    widget, Bound, EventType, Index, MutableBound, OnEvent, WidgetProps,
+    widget, Bound, EventType, Index, MutableBound, OnEvent,
 };
 use kayak_ui::widgets::{App, Button, If, Text, Window};
 
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct RemovalProps {}
-
 #[widget]
-fn Removal(props: RemovalProps) {
+fn Removal() {
     let text_styles = Style {
         bottom: StyleProp::Value(Units::Stretch(1.0)),
         left: StyleProp::Value(Units::Stretch(0.1)),

--- a/examples/provider.rs
+++ b/examples/provider.rs
@@ -138,14 +138,11 @@ fn ThemeButton(props: ThemeButtonProps) {
     }
 }
 
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct ThemeSelectorProps {}
-
 /// A widget displaying a set of [ThemeButton] widgets
 ///
 /// This is just an abstracted container. Not much to see here...
 #[widget]
-fn ThemeSelector(props: ThemeSelectorProps) {
+fn ThemeSelector() {
     let vampire_theme = Theme::vampire();
     let solar_theme = Theme::solar();
     let vector_theme = Theme::vector();

--- a/examples/tabs/tabs.rs
+++ b/examples/tabs/tabs.rs
@@ -15,7 +15,7 @@ use kayak_ui::{
     core::{
         constructor, render, rsx,
         styles::{Style, StyleProp, Units},
-        widget, Color, Index, WidgetProps,
+        widget, Color, Index,
     },
     widgets::{App, Text, Window},
 };
@@ -30,11 +30,8 @@ mod tab_box;
 mod tab_content;
 mod theming;
 
-#[derive(WidgetProps, Default, Debug, PartialEq, Clone)]
-pub struct TabDemoProps {}
-
 #[widget]
-fn TabDemo(props: TabDemoProps) {
+fn TabDemo() {
     let text_style = Style {
         width: StyleProp::Value(Units::Percentage(75.0)),
         top: StyleProp::Value(Units::Stretch(0.5)),

--- a/examples/text_box.rs
+++ b/examples/text_box.rs
@@ -9,15 +9,12 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{Style, StyleProp, Units},
-    widget, Index, WidgetProps,
+    widget, Index,
 };
 use kayak_ui::widgets::{App, OnChange, TextBox, Window};
 
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct TextBoxExampleProps {}
-
 #[widget]
-fn TextBoxExample(props: TextBoxExampleProps) {
+fn TextBoxExample() {
     let (value, set_value, _) = use_state!("I started with a value!".to_string());
     let (empty_value, set_empty_value, _) = use_state!("".to_string());
     let (red_value, set_red_value, _) = use_state!("This text is red".to_string());

--- a/examples/todo/todo.rs
+++ b/examples/todo/todo.rs
@@ -7,7 +7,7 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{LayoutType, Style, StyleProp, Units},
-    use_state, widget, EventType, Handler, Index, OnEvent, WidgetProps,
+    use_state, widget, EventType, Handler, Index, OnEvent,
 };
 use kayak_ui::widgets::{App, Element, OnChange, TextBox, Window};
 
@@ -23,11 +23,8 @@ pub struct Todo {
     name: String,
 }
 
-#[derive(WidgetProps, Clone, Debug, Default, PartialEq)]
-struct TodoAppProps {}
-
 #[widget]
-fn TodoApp(props: TodoAppProps) {
+fn TodoApp() {
     let (todos, set_todos, ..) = use_state!(vec![
         Todo {
             name: "Use bevy to make a game!".to_string(),

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -5,15 +5,11 @@ use bevy::{
 };
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
 use kayak_ui::core::Index;
-use kayak_ui::core::WidgetProps;
 use kayak_ui::core::{render, rsx, widget};
 use kayak_ui::widgets::{App, Inspector, Window};
 
-#[derive(WidgetProps, Default, Debug, PartialEq, Clone)]
-pub struct Props {}
-
 #[widget]
-fn CustomWidget(props: Props) {
+fn CustomWidget() {
     rsx! {
         <>
             <Window draggable={true} position={(50.0, 50.0)} size={(300.0, 300.0)} title={"Window 1".to_string()}>

--- a/examples/world_interaction.rs
+++ b/examples/world_interaction.rs
@@ -20,7 +20,7 @@ use kayak_ui::{
     core::{
         render, rsx,
         styles::{Style, StyleProp, Units},
-        use_state, widget, EventType, Index, OnEvent, WidgetProps,
+        use_state, widget, EventType, Index, OnEvent,
     },
     widgets::{App, Button, Text, Window},
 };
@@ -65,11 +65,8 @@ fn set_active_tile_target(
     tile.target = tile_pos;
 }
 
-#[derive(WidgetProps, Default, Debug, PartialEq, Clone)]
-pub struct ControlPanelProps {}
-
 #[widget]
-fn ControlPanel(props: ControlPanelProps) {
+fn ControlPanel() {
     let text_styles = Style {
         left: StyleProp::Value(Units::Stretch(1.0)),
         right: StyleProp::Value(Units::Stretch(1.0)),

--- a/kayak_core/src/widget.rs
+++ b/kayak_core/src/widget.rs
@@ -15,8 +15,8 @@ pub trait SealedWidget {}
 /// all implementors of [Widget].
 pub trait BaseWidget: SealedWidget + std::fmt::Debug + Send + Sync {
     fn constructor<P: WidgetProps>(props: P) -> Self
-    where
-        Self: Sized;
+        where
+            Self: Sized;
     fn get_id(&self) -> Index;
     fn set_id(&mut self, id: Index);
     fn get_props(&self) -> &dyn WidgetProps;
@@ -32,8 +32,8 @@ pub trait Widget: std::fmt::Debug + Clone + Default + PartialEq + AsAny + Send +
 
     /// Construct the widget with the given props
     fn constructor(props: Self::Props) -> Self
-    where
-        Self: Sized;
+        where
+            Self: Sized;
 
     /// Get this widget's ID
     fn get_id(&self) -> Index;
@@ -79,12 +79,12 @@ pub trait WidgetProps: std::fmt::Debug + AsAny + Send + Sync {
 }
 
 impl<T> BaseWidget for T
-where
-    T: Widget + Clone + PartialEq + Default,
+    where
+        T: Widget + Clone + PartialEq + Default,
 {
     fn constructor<P: WidgetProps>(props: P) -> Self
-    where
-        Self: Sized,
+        where
+            Self: Sized,
     {
         let props: Box<dyn Any> = Box::new(props);
         Widget::constructor(*props.downcast::<<T as Widget>::Props>().unwrap())
@@ -120,3 +120,23 @@ where
 }
 
 impl<T> SealedWidget for T where T: Widget {}
+
+impl WidgetProps for () {
+    fn get_children(&self) -> Option<Children> {
+        None
+    }
+
+    fn set_children(&mut self, _children: Option<Children>) {}
+
+    fn get_styles(&self) -> Option<Style> {
+        None
+    }
+
+    fn get_on_event(&self) -> Option<OnEvent> {
+        None
+    }
+
+    fn get_focusable(&self) -> Option<bool> {
+        None
+    }
+}

--- a/kayak_core/src/widget.rs
+++ b/kayak_core/src/widget.rs
@@ -15,8 +15,8 @@ pub trait SealedWidget {}
 /// all implementors of [Widget].
 pub trait BaseWidget: SealedWidget + std::fmt::Debug + Send + Sync {
     fn constructor<P: WidgetProps>(props: P) -> Self
-        where
-            Self: Sized;
+    where
+        Self: Sized;
     fn get_id(&self) -> Index;
     fn set_id(&mut self, id: Index);
     fn get_props(&self) -> &dyn WidgetProps;
@@ -32,8 +32,8 @@ pub trait Widget: std::fmt::Debug + Clone + Default + PartialEq + AsAny + Send +
 
     /// Construct the widget with the given props
     fn constructor(props: Self::Props) -> Self
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 
     /// Get this widget's ID
     fn get_id(&self) -> Index;
@@ -79,12 +79,12 @@ pub trait WidgetProps: std::fmt::Debug + AsAny + Send + Sync {
 }
 
 impl<T> BaseWidget for T
-    where
-        T: Widget + Clone + PartialEq + Default,
+where
+    T: Widget + Clone + PartialEq + Default,
 {
     fn constructor<P: WidgetProps>(props: P) -> Self
-        where
-            Self: Sized,
+    where
+        Self: Sized,
     {
         let props: Box<dyn Any> = Box::new(props);
         Widget::constructor(*props.downcast::<<T as Widget>::Props>().unwrap())

--- a/kayak_render_macros/src/function_component.rs
+++ b/kayak_render_macros/src/function_component.rs
@@ -4,7 +4,7 @@ use proc_macro2::Ident;
 use proc_macro_error::emit_error;
 use quote::{format_ident, quote};
 use syn::spanned::Spanned;
-use syn::{FnArg, parse_quote, Pat, Signature, Type};
+use syn::{parse_quote, FnArg, Pat, Signature, Type};
 
 const DEFAULT_PROP_IDENT: &str = "__props";
 
@@ -100,7 +100,7 @@ fn get_props(signature: &Signature) -> Option<(Ident, Type)> {
 
     if signature.inputs.len() == 0 {
         let ident = format_ident!("{}", DEFAULT_PROP_IDENT);
-        let ty: Type = parse_quote!{()};
+        let ty: Type = parse_quote! {()};
         return Some((ident, ty));
     }
 
@@ -116,7 +116,7 @@ fn get_props(signature: &Signature) -> Option<(Ident, Type)> {
 
             let ty = *typed.ty.clone();
             match &ty {
-                Type::Path(..) => {},
+                Type::Path(..) => {}
                 err => {
                     emit_error!(err.span(), "Invalid widget prop type: {:?}", err);
                     return None;

--- a/kayak_render_macros/src/function_component.rs
+++ b/kayak_render_macros/src/function_component.rs
@@ -1,9 +1,12 @@
 use crate::get_core_crate;
 use proc_macro::TokenStream;
+use proc_macro2::Ident;
 use proc_macro_error::emit_error;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::spanned::Spanned;
-use syn::{FnArg, Pat, Type};
+use syn::{FnArg, parse_quote, Pat, Signature, Type};
+
+const DEFAULT_PROP_IDENT: &str = "__props";
 
 pub struct WidgetArguments {
     pub focusable: bool,
@@ -19,43 +22,10 @@ pub fn create_function_widget(f: syn::ItemFn, _widget_arguments: WidgetArguments
     let struct_name = f.sig.ident.clone();
     let (impl_generics, ty_generics, where_clause) = f.sig.generics.split_for_impl();
 
-    if f.sig.inputs.len() != 1 {
-        let span = if f.sig.inputs.len() > 0 {
-            f.sig.inputs.span()
-        } else {
-            f.sig.span()
-        };
-        emit_error!(
-            span,
-            "Functional widgets expect exactly one argument (their props), but was given {}",
-            f.sig.inputs.len()
-        );
-    }
-
-    let (props, prop_type) = match f.sig.inputs.first().unwrap() {
-        FnArg::Typed(typed) => {
-            let ident = match *typed.pat.clone() {
-                Pat::Ident(ident) => ident.ident,
-                err => {
-                    emit_error!(err.span(), "Expected identifier, but got {:?}", err);
-                    return TokenStream::new();
-                }
-            };
-
-            let ty = match *typed.ty.clone() {
-                Type::Path(type_path) => type_path.path,
-                err => {
-                    emit_error!(err.span(), "Invalid widget prop type: {:?}", err);
-                    return TokenStream::new();
-                }
-            };
-
-            (ident, ty)
-        }
-        FnArg::Receiver(receiver) => {
-            emit_error!(receiver.span(), "Functional widget cannot use 'self'");
-            return TokenStream::new();
-        }
+    let (props, prop_type) = if let Some(parsed) = get_props(&f.sig) {
+        parsed
+    } else {
+        return TokenStream::new();
     };
 
     let block = f.block;
@@ -111,4 +81,53 @@ pub fn create_function_widget(f: syn::ItemFn, _widget_arguments: WidgetArguments
             }
         }
     })
+}
+
+fn get_props(signature: &Signature) -> Option<(Ident, Type)> {
+    if signature.inputs.len() > 1 {
+        let span = if signature.inputs.len() > 0 {
+            signature.inputs.span()
+        } else {
+            signature.span()
+        };
+        emit_error!(
+            span,
+            "Functional widgets expect at most one argument (their props), but was given {}",
+            signature.inputs.len()
+        );
+        return None;
+    }
+
+    if signature.inputs.len() == 0 {
+        let ident = format_ident!("{}", DEFAULT_PROP_IDENT);
+        let ty: Type = parse_quote!{()};
+        return Some((ident, ty));
+    }
+
+    match signature.inputs.first().unwrap() {
+        FnArg::Typed(typed) => {
+            let ident = match *typed.pat.clone() {
+                Pat::Ident(ident) => ident.ident,
+                err => {
+                    emit_error!(err.span(), "Expected identifier, but got {:?}", err);
+                    return None;
+                }
+            };
+
+            let ty = *typed.ty.clone();
+            match &ty {
+                Type::Path(..) => {},
+                err => {
+                    emit_error!(err.span(), "Invalid widget prop type: {:?}", err);
+                    return None;
+                }
+            };
+
+            Some((ident, ty))
+        }
+        FnArg::Receiver(receiver) => {
+            emit_error!(receiver.span(), "Functional widget cannot use 'self'");
+            return None;
+        }
+    }
 }


### PR DESCRIPTION
## Objective

Make widgets that don't require props, easier to write. This comes in handy for fully contained widgets or widgets written for examples.

## Solution

Implemented `WidgetProps` over the unit type (`()`). Also made it so that functional widgets defined with zero arguments use this empty prop type.