### PR TITLE
Forwarded attributes on functional widgets

### DIFF
--- a/kayak_render_macros/examples/main.rs
+++ b/kayak_render_macros/examples/main.rs
@@ -5,6 +5,7 @@ use kayak_render_macros::{rsx, use_state, widget, WidgetProps};
 #[derive(WidgetProps, Clone, Default, Debug, PartialEq)]
 #[allow(dead_code)]
 struct TestProps {
+    /// A test prop
     foo: u32,
     #[prop_field(Styles)]
     styles: Option<Style>,
@@ -14,6 +15,7 @@ struct TestProps {
     on_event: Option<kayak_core::OnEvent>,
 }
 
+/// A test widget
 #[widget]
 fn Test(props: TestProps) {
     let _ = use_state!(props.foo);

--- a/kayak_render_macros/examples/main.rs
+++ b/kayak_render_macros/examples/main.rs
@@ -15,8 +15,8 @@ struct TestProps {
     on_event: Option<kayak_core::OnEvent>,
 }
 
-/// A test widget
 #[widget]
+/// A test widget
 fn Test(props: TestProps) {
     let _ = use_state!(props.foo);
     let children = props.get_children();

--- a/kayak_render_macros/src/function_component.rs
+++ b/kayak_render_macros/src/function_component.rs
@@ -28,12 +28,14 @@ pub fn create_function_widget(f: syn::ItemFn, _widget_arguments: WidgetArguments
         return TokenStream::new();
     };
 
+    let attrs = f.attrs;
     let block = f.block;
     let vis = f.vis;
 
     let kayak_core = get_core_crate();
 
     TokenStream::from(quote! {
+        #(#attrs)*
         #[derive(Default, Debug, PartialEq, Clone)]
         #vis struct #struct_name #impl_generics {
             pub id: #kayak_core::Index,


### PR DESCRIPTION
## Objective

Pass attributes on functional widgets to the generated widget structs.

Closes #62.

## Solution

In the render macro, took attributes from the function definition and added them to the generated struct.

Attributes that can normally be applied to functions are allowed to be placed before the `#[widget]` macro, but we should probably try to standardize putting attributes below it. This is because attributes that cannot be applied to functions (such as derives) _must_ be placed below so as to be captured by the `#[widget]` macro. So making this standard across the codebase should help promote others to do the same (even if they don't know why).

All in all this works out to something like:

```rust
#[widget]
/// This is MY widget!
#[derive(Hash)]
fn MyWidget(props: MyWidgetProps) {
  // ...
}
```