### PR TITLE
bevy_kayak_renderer: Fix clipping not working

### DIFF
--- a/bevy_kayak_renderer/src/lib.rs
+++ b/bevy_kayak_renderer/src/lib.rs
@@ -27,6 +27,8 @@ pub struct WindowSize(pub f32, pub f32);
 fn update_window_size(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,
+    windows: Res<Windows>,
+    mut window_size: ResMut<WindowSize>,
 ) {
     let mut changed_window_ids = Vec::new();
     // handle resize events. latest events are handled first because we only want to resize each
@@ -47,6 +49,14 @@ fn update_window_size(
         }
 
         changed_window_ids.push(event.id);
+    }
+
+    for window_id in changed_window_ids {
+        if let Some(window) = windows.get(window_id) {
+            let width = window.width();
+            let height = window.height();
+            *window_size = WindowSize(width, height);
+        }
     }
 }
 

--- a/bevy_kayak_renderer/src/render/unified/pipeline.rs
+++ b/bevy_kayak_renderer/src/render/unified/pipeline.rs
@@ -597,7 +597,7 @@ impl Draw<TransparentUI> for DrawUI {
             let mut height = extracted_quad.rect.height() as u32;
             width = width.min(window_size.0 as u32);
             height = height.min(window_size.1 as u32);
-            if width == 0 || height == 0 {
+            if width == 0 || height == 0 || x > window_size.0 as u32 || y > window_size.1 as u32 {
                 return;
             }
             if x + width > window_size.0 as u32 {

--- a/bevy_kayak_renderer/src/render/unified/pipeline.rs
+++ b/bevy_kayak_renderer/src/render/unified/pipeline.rs
@@ -597,7 +597,7 @@ impl Draw<TransparentUI> for DrawUI {
             let mut height = extracted_quad.rect.height() as u32;
             width = width.min(window_size.0 as u32);
             height = height.min(window_size.1 as u32);
-            if width == 0 || height == 0 || x > width || y > height {
+            if width == 0 || height == 0 {
                 return;
             }
             if x + width > window_size.0 as u32 {


### PR DESCRIPTION
## Objective

Fixes #85.

Clipping was broken after the extraction of the renderer due to `WindowSize` not being updated in the render app.

There was another issue present before that, though, which caused clipping to fail on wider wider windows. And upon inspection it actually fails for any position greater than its size (which often happens when a window is stretched and the elements move along with it). For example, if the clipped element had a width of `200` and an x-position of `199`, it would be fine. However, setting the x-position to `201` would result in the clip breaking.

## Solution

Update `WindowSize` and remove the code that checks if the position is greater than the size.

This seems to fix the issues, but @TheRawMeatball does this break anything for your use cases with ui4? I imagine it should be okay, but just wanted to check.