### PR TITLE
Fixed missed layouts for on_layout

### DIFF
--- a/kayak_core/src/layout.rs
+++ b/kayak_core/src/layout.rs
@@ -65,6 +65,11 @@ pub struct LayoutEvent {
     /// Layout of target component
     pub layout: Layout,
     /// Flags denoting the layout change.
+    ///
+    /// Note: The flags can potentially all be unset in cases where the [target's] layout did
+    /// not change, but one of its immediate children did.
+    ///
+    /// [target's]: LayoutEvent::target
     pub flags: GeometryChanged,
     /// The node ID of the element receiving the layout event.
     pub target: Index,

--- a/kayak_core/src/layout_dispatcher.rs
+++ b/kayak_core/src/layout_dispatcher.rs
@@ -1,5 +1,5 @@
-use indexmap::IndexSet;
-use morphorm::Cache;
+use indexmap::IndexMap;
+use morphorm::GeometryChanged;
 
 use crate::{Index, KayakContext, KayakContextRef, LayoutEvent};
 
@@ -7,53 +7,42 @@ pub(crate) struct LayoutEventDispatcher;
 
 impl LayoutEventDispatcher {
     pub fn dispatch(context: &mut KayakContext) {
-        let dirty_nodes: Vec<Index> = context
+        let changed = context
             .widget_manager
-            .dirty_render_nodes
-            .drain(..)
-            .collect();
+            .layout_cache
+            .iter_changed()
+            .map(|(index, flags)| (*index, *flags))
+            .collect::<IndexMap<Index, GeometryChanged>>();
 
         // Use IndexSet to prevent duplicates and maintain speed
-        let mut parents: IndexSet<Index> = IndexSet::default();
+        let mut parents: IndexMap<Index, GeometryChanged> = IndexMap::default();
 
-        for node_index in dirty_nodes {
-            // If layout is not changed -> skip
-            if context
-                .widget_manager
-                .layout_cache
-                .geometry_changed(node_index)
-                .is_empty()
-            {
-                continue;
-            }
-
+        for (node_index, flags) in &changed {
             // Add parent to set
-            if let Some(parent_index) = context.widget_manager.tree.get_parent(node_index) {
-                parents.insert(parent_index);
+            if let Some(parent_index) = context.widget_manager.tree.get_parent(*node_index) {
+                if !changed.contains_key(&parent_index) {
+                    parents.insert(parent_index, GeometryChanged::default());
+                }
             }
 
             // Process and dispatch
-            Self::process(node_index, context);
+            Self::process(*node_index, *flags, context);
         }
 
         // Finally, process all parents
-        for parent_index in parents {
+        for (parent_index, flags) in parents {
             // Process and dispatch
-            Self::process(parent_index, context);
+            Self::process(parent_index, flags, context);
         }
     }
 
-    fn process(index: Index, context: &mut KayakContext) {
+    fn process(index: Index, flags: GeometryChanged, context: &mut KayakContext) {
         // We should be able to just get layout from WidgetManager here
         // since the layouts will be calculated by this point
         let widget = context.widget_manager.take(index);
         if let Some(on_layout) = widget.get_props().get_on_layout() {
             if let Some(rect) = context.widget_manager.layout_cache.rect.get(&index) {
-                let layout_event = LayoutEvent::new(
-                    *rect,
-                    context.widget_manager.layout_cache.geometry_changed(index),
-                    index,
-                );
+                let layout_event = LayoutEvent::new(*rect, flags, index);
                 let mut context_ref = KayakContextRef::new(context, Some(index));
 
                 on_layout.try_call(&mut context_ref, &layout_event);

--- a/kayak_core/src/widget_manager.rs
+++ b/kayak_core/src/widget_manager.rs
@@ -172,8 +172,8 @@ impl WidgetManager {
     pub fn render(&mut self) {
         let initial_styles = Style::initial();
         let default_styles = Style::new_default();
-        for dirty_node_index in &self.dirty_render_nodes {
-            let dirty_widget = self.current_widgets[*dirty_node_index].as_ref().unwrap();
+        for dirty_node_index in self.dirty_render_nodes.drain(..) {
+            let dirty_widget = self.current_widgets[dirty_node_index].as_ref().unwrap();
             // Get the parent styles. Will be one of the following:
             // 1. Already-resolved node styles (best)
             // 2. Unresolved widget prop styles
@@ -232,13 +232,13 @@ impl WidgetManager {
                 .unwrap_or(vec![]);
 
             let mut node = NodeBuilder::empty()
-                .with_id(*dirty_node_index)
+                .with_id(dirty_node_index)
                 .with_styles(styles, raw_styles)
                 .with_children(children)
                 .build();
             node.z = current_z;
 
-            self.nodes[*dirty_node_index] = Some(node);
+            self.nodes[dirty_node_index] = Some(node);
         }
 
         self.node_tree = self.build_nodes_tree();


### PR DESCRIPTION
## Objective

With #90 merged, I was toying around with it and realized I had forgotten a key factor for layout in #86. What I had failed to realize was that `dirty_render_nodes` do not encapsulate all layout changes. My mistake was thinking that layout changes are only possible through updating our widgets.

While it's true that `dirty_render_nodes` likely update their own layout, it turns out that they may also update other nodes' layout. This causes us to sometimes "skip" nodes that should have received a call to `on_layout`.

For example, we might update a state variable that changes the width of a widget. It will be inserted into our `dirty_render_nodes` set but its siblings will not— even though this change in width likely affects their layout as well. In this case, only the former (which includes its parent and children) will have `on_layout` called.

## Solution

Make a small correction to how we get nodes for layout dispatching. Instead of using `dirty_render_nodes`, we now get the changed nodes from the `LayoutCache` directly, which should guarantee that we have all nodes whose layout has changed.