### PR TITLE
kayak_core: Add style resolution helpers

### DIFF
--- a/kayak_core/src/render_primitive.rs
+++ b/kayak_core/src/render_primitive.rs
@@ -2,7 +2,7 @@ use crate::{
     color::Color,
     layout_cache::Rect,
     render_command::RenderCommand,
-    styles::{Corner, Edge, Style, StyleProp},
+    styles::{Corner, Edge, Style},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -56,35 +56,17 @@ impl From<&Style> for RenderPrimitive {
     fn from(style: &Style) -> Self {
         let render_command = style.render_command.resolve();
 
-        let background_color = if matches!(style.background_color, StyleProp::Default) {
-            Color::TRANSPARENT
-        } else {
-            style.background_color.resolve()
-        };
+        let background_color = style.background_color.resolve_or(Color::TRANSPARENT);
 
-        let border_color = if matches!(style.border_color, StyleProp::Default) {
-            Color::TRANSPARENT
-        } else {
-            style.border_color.resolve()
-        };
+        let border_color = style.border_color.resolve_or(Color::TRANSPARENT);
 
-        let font = if matches!(style.font, StyleProp::Default) {
-            String::from(crate::DEFAULT_FONT)
-        } else {
-            style.font.resolve()
-        };
+        let font = style
+            .font
+            .resolve_or_else(|| String::from(crate::DEFAULT_FONT));
 
-        let font_size = if matches!(style.font_size, StyleProp::Default) {
-            14.0
-        } else {
-            style.font_size.resolve()
-        };
+        let font_size = style.font_size.resolve_or(14.0);
 
-        let line_height = if matches!(style.line_height, StyleProp::Default) {
-            font_size * 1.2
-        } else {
-            style.line_height.resolve()
-        };
+        let line_height = style.line_height.resolve_or(font_size * 1.2);
 
         match render_command {
             RenderCommand::Empty => Self::Empty,

--- a/kayak_core/src/styles/mod.rs
+++ b/kayak_core/src/styles/mod.rs
@@ -60,6 +60,30 @@ where
         }
     }
 
+    /// Returns the concrete value of this style property or the provided default.
+    ///
+    /// If this style property is not [`StyleProp::Value`], then the provided default
+    /// will be returned.
+    pub fn resolve_or(&self, default: T) -> T {
+        if let Self::Value(value) = self {
+            value.clone()
+        } else {
+            default
+        }
+    }
+
+    /// Returns the concrete value of this style property or computes it from a closure.
+    ///
+    /// If this style property is not [`StyleProp::Value`], then the return value will be
+    /// computed from the provided closure.
+    pub fn resolve_or_else<F: FnOnce() -> T>(&self, f: F) -> T {
+        if let Self::Value(value) = self {
+            value.clone()
+        } else {
+            f()
+        }
+    }
+
     /// Returns the first property to not be [unset](StyleProp::Unset)
     ///
     /// If none found, returns [`StyleProp::Unset`]
@@ -505,5 +529,14 @@ mod tests {
         let property: StyleProp<_> = expected_width.into();
 
         assert_eq!(expected, property);
+    }
+
+    #[test]
+    fn value_should_resolve_with_given_value() {
+        let expected = 123.0;
+        let property = StyleProp::Default;
+
+        assert_eq!(expected, property.resolve_or(expected));
+        assert_eq!(expected, property.resolve_or_else(|| expected));
     }
 }

--- a/kayak_core/src/styles/mod.rs
+++ b/kayak_core/src/styles/mod.rs
@@ -45,7 +45,7 @@ impl<T> StyleProp<T>
 where
     T: Default + Clone,
 {
-    /// Resolves this style property into a concrete value
+    /// Resolves this style property into a concrete value.
     ///
     /// # Panics
     ///
@@ -81,6 +81,18 @@ where
             value.clone()
         } else {
             f()
+        }
+    }
+
+    /// Returns the concrete value of this style property or the default value.
+    ///
+    /// This is similar to the standard [`resolve`](Self::resolve) method, however, it
+    /// will _not_ panic on a [`StyleProp::Inherit`].
+    pub fn resolve_or_default(&self) -> T {
+        if let Self::Value(value) = self {
+            value.clone()
+        } else {
+            T::default()
         }
     }
 
@@ -533,10 +545,11 @@ mod tests {
 
     #[test]
     fn value_should_resolve_with_given_value() {
-        let expected = 123.0;
+        let expected: f32 = 123.0;
         let property = StyleProp::Default;
 
         assert_eq!(expected, property.resolve_or(expected));
         assert_eq!(expected, property.resolve_or_else(|| expected));
+        assert_eq!(f32::default(), property.resolve_or_default());
     }
 }


### PR DESCRIPTION
## Objective

There are times when we need to either resolve a `StyleProp` or use some default value. Just using `resolve` by itself means we need to worry about two things:

1. Panicking on `StyleProp::Inherit`
2. Not getting a custom default

To account for these we normally do something like:

```rust
let value = match prop {
  StyleProp::Value(value) => value,
  _ => SOME_DEFAULT
};
```

## Solution

Added the following methods (all based on those from `Option`):

* `resolve_or` - Resolves the value or returns the given default
* `resolve_or_else` - Resolves the value or returns a computed default
* `resolve_or_default` - Resolves the value or returns the default (like `resolve` but doesn't panic)

### Example

Our previous snippet could then be written as:

```rust
let value = prop.resolve_or(SOME_DEFAULT);
```
