### PR TITLE
Start upgrade to bevy 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,18 +186,18 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bevy"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97342ea2f3bad36be2ded1d1fbd569ff83147b70697f12f1579e87a7480afa36"
+checksum = "4fce306d40a111309ee61d4626efbafccdd46bb80657122c38061fa7264c08e4"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy-crevice-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cf594c9277eb1e426f45a00eaf70aa9ffdf479268d7e4538270263811e20bc"
+checksum = "191a752a01c3402deb24320acf42288bf822e5d22f19ae1d903797f02e9b0c33"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -206,10 +206,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_app"
-version = "0.6.0"
+name = "bevy_animation"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fe3d3f4140fb11cd294f43be7cb66a5783d9277ba0270743e2860e32b25ab5"
+checksum = "c087569c34b168dd988e8b3409ce273661b4a58c3c534d0e381950589f59f68e"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_core",
+ "bevy_ecs",
+ "bevy_hierarchy",
+ "bevy_math",
+ "bevy_reflect",
+ "bevy_transform",
+ "bevy_utils",
+]
+
+[[package]]
+name = "bevy_app"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32660ae99fa3498ca379de28b7e2f447e6531b0e432bf200901efeec075553c1"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -221,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb68a0259e2f857a32c4f05eb9b9447db1072297c61864ad07d02fea1838bde9"
+checksum = "f2afd395240087924ba49c8cae2b00d007aeb1db53ee726a543b1e90dce2d3ab"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -249,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0291276cf0dd1dbbf3393112d0e0276e4110f633965542123b830d8dae44fff3"
+checksum = "73a1c827ae837b62868539040176fb6d4daecf24983b98a0284d158e52cd21d5"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -265,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_core"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c156430a5312c04a1b25fa434eeeab6349a41c6bb96ea0385406d53b3c43658"
+checksum = "12c0f8614b6014671ab60bacb8bf681373d08b0bb15633b8ef72b895cf966d29"
 dependencies = [
  "bevy_app",
  "bevy_derive",
@@ -281,22 +298,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b422dca94195c904964ab21bc4557fbd11f692c299d46e38364715ac931841e"
+checksum = "74d570bc9310196190910a5b1ffd8c8c35bd6b73f918d0651ae3c3d4e57be9a7"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_ecs",
  "bevy_render",
+ "bevy_utils",
 ]
 
 [[package]]
 name = "bevy_crevice"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c684de72f710da0a701d1d2fe2a481241709d66f43215bcc9d7f9f0818d1cb15"
+checksum = "3da0a284fb26c02cb96ef4d5bbf4de5fad7e1a901730035a61813bf64e28482e"
 dependencies = [
  "bevy-crevice-derive",
  "bytemuck",
@@ -306,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918dc0dff01e8b4e8f989db89d74fd4042810ea80a70642d0459b3c265995e59"
+checksum = "6abddf2ed415f31d28a9bf9ab3c0bc857e98a722858d38dba65bdda481f8d714"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -317,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbe98f48873d4b20f6479723de18d957f4bc00c653efd36c245e6a66d6e8b71"
+checksum = "6ebf72ea058cfc379756e9da7de6861174e1860504f41e3e5a46d5b1c35d6644"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -330,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6daf05da2680a14b17a4b669879fa7186abb80e7fbe400fb02c0c62628d1e200"
+checksum = "79e67dd06b14e787d2026fe6e2b63f67482afcc62284f20ea2784d8b0662e95f"
 dependencies = [
  "async-channel",
  "bevy_ecs_macros",
@@ -348,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e9e664b3ea45cfc9ab3251ee0255dfa6410f675b3a405e7bac8e59b2d76aa9"
+checksum = "718923a491490bd81074492d61fc08134f9c62a29ba8666818cd7a6630421246"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -360,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b457f720b1c54ede34afd6007beae3708503c0dd7a4ab4b416e36cb8bbd05ac1"
+checksum = "15b164983e8057a1a730412a7c26ccc540d9ce76d2c6ab68edd258a0baeb1762"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -373,16 +391,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4711f4f77542dccd59eec249c98f02e34e28a25ee079c14cd351061d08e5c"
+checksum = "2e07bda7721091c1a683343d466132dc69dec65aa83d8c9e328a2fb3431f03be"
 dependencies = [
  "anyhow",
  "base64",
+ "bevy_animation",
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_log",
  "bevy_math",
  "bevy_pbr",
@@ -397,10 +417,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_input"
-version = "0.6.0"
+name = "bevy_hierarchy"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33989693efa636960dd40e540029ed7b7bc1af2f3eef26c009555b5e2a4e185a"
+checksum = "2f407f152f35541a099484200afe3b0ca09ce625469e8233dcdc264d6f88e01a"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_reflect",
+ "bevy_utils",
+ "smallvec",
+]
+
+[[package]]
+name = "bevy_input"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4ec4f6e38ef1b41ff68ec7badd6afc5c9699191e61e511c4abee91a5888afc"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -410,10 +443,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92af28d95bba80d11840c24fa4ce8ff84ae27af1def2f5cf8a6891acce5d714"
+checksum = "d518a8e5f526a9537fc8408a284caec7af22b23c3b23c0dee08bacc0930e2f1a"
 dependencies = [
+ "bevy_animation",
  "bevy_app",
  "bevy_asset",
  "bevy_audio",
@@ -424,6 +458,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_gilrs",
  "bevy_gltf",
+ "bevy_hierarchy",
  "bevy_input",
  "bevy_log",
  "bevy_math",
@@ -470,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf0083e72bf76cbfa6607311ac6baef2f4f7c9306c35942cece8c0589cd3e5e"
+checksum = "943ec496720ded2ff62b292d8e5fc845817a504915f41b7c5fd12b1380300f75"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -485,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf90b3b67606d0818cdac6c9134eb66fa174959977a4abba893364a571a7cd"
+checksum = "b7ddfc33a99547e36718e56e414541e461c74ec318ff987a1e9f4ff46d0dacbb"
 dependencies = [
  "cargo-manifest",
  "quote",
@@ -496,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0f9ebf2ef80a8fff3e5dca817594071004048cd089e72b9a1bf4e494b66112"
+checksum = "20288df0f70ff258bbaffaf55209f1271a7436438591bbffc3d81e4d84b423f2"
 dependencies = [
  "bevy_reflect",
  "glam",
@@ -506,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_pbr"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41724d89746d54f7f8c8e522f9d0b1232a8a289e0d270482175d23774dc2362a"
+checksum = "06adee54840f18cfeda7af4cdc57608644fa840be076a562353f896bfdb9c694"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -527,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84ce8cbd484a39d67171831eaf72c20d2684de71f1e9d79333c8dd6d6f3ebca"
+checksum = "4d0793107bc4b7c6bd04232d739fc8d70aa5fb313bfad6e850f91f79b2557eed"
 dependencies = [
  "bevy_reflect_derive",
  "bevy_utils",
@@ -544,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af3100febf44583a7c052d1469fbdb411f56aa85729333a0ac106a016bd379c"
+checksum = "81c88de8067d19dfde31662ee78e3ee6971e2df27715799f91b515b37a636677"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -557,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0d5409e5e3d48f3192f78e37bedea29aa0c674083e51aaa7e945496913d2c2"
+checksum = "6a358da8255b704153913c3499b3693fa5cfe13a48725ac6e76b043fa5633bc8"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -593,16 +628,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eb2b01e4d1b074c75ea59a92409739cac24b56b1c723491ef80936d50e95df"
+checksum = "2ea240f2ffce9f58a5601cc5ead24111f577dc4c656452839eb1fdf4b7a28529"
 dependencies = [
  "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_reflect",
- "bevy_transform",
  "bevy_utils",
  "ron",
  "serde",
@@ -612,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66439831ff57c11c7fb2692e7ccf8d0551f4368a9908908d3c38f2da53115b33"
+checksum = "5fcecfbc623410137d85a71a295ff7c16604b7be24529c9ea4b9a9881d7a142b"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -638,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc4bce7f4cddbb489636092f52478b103dc26ee8526c585289bbdd9c0d0a99f"
+checksum = "db2b0f0b86c8f78c53a2d4c669522f45e725ed9d9c3d734f54ec30876494e04e"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -652,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233c4bb933435e8e6c34a1310317fd7f8c6617526270de572e643816070b236a"
+checksum = "a206112de011fd6baebaf476af69d87f4e38a1314b65e3c872060830d7c0b9fa"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -676,23 +711,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9974c494f9cc721df46d2ba27c6a8df2a955ed8360a23adabd2bd66d1f73fa8f"
+checksum = "aa2f7a77900fb23f24ca312c1f8df3eb47a45161326f41e9b4ef05b039793503"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
- "bevy_utils",
- "smallvec",
 ]
 
 [[package]]
 name = "bevy_ui"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbdb34595bd7be349fba8038b970acbe632f70b98737318b2327c7c7cd557767"
+checksum = "c65e79658d8a3d4da087a6fb8b229cfe1455cda2c4e8e6305b3b44fb46fb1d30"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -700,6 +734,7 @@ dependencies = [
  "bevy_core_pipeline",
  "bevy_derive",
  "bevy_ecs",
+ "bevy_hierarchy",
  "bevy_input",
  "bevy_log",
  "bevy_math",
@@ -718,13 +753,14 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252f6674aa3ba68bacfec506b91570a3cc206ad09b7ef4b23661959ef0246396"
+checksum = "2f354c584812996febd48cc885f36b23004b49d6680e73fc95a69a2bb17a48e5"
 dependencies = [
  "ahash",
  "bevy_derive",
  "getrandom",
+ "hashbrown",
  "instant",
  "tracing",
  "uuid",
@@ -732,11 +768,12 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4b52b766baf565e96f24f61dbc51bc85151f23202fed2b3650769f2edd0b21"
+checksum = "04fe33d177e10b2984fa90c1d19496fc6f6e7b36d4442699d359e2b4b507873d"
 dependencies = [
  "bevy_app",
+ "bevy_ecs",
  "bevy_math",
  "bevy_utils",
  "raw-window-handle",
@@ -745,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d4a4bed46200615e070897a551d2389d49cdaff048e825e7fa6caef4dc57c6"
+checksum = "a7c0e3b94cc73907f8a9f82945ca006a39ed2ab401aca0974b47a007a468509f"
 dependencies = [
  "approx",
  "bevy_app",
@@ -1555,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "gltf"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff38b75359a0096dd0a8599b6e4f37a6ee41d5df300cc7669e62aafa697f7a2"
+checksum = "00e0a0eace786193fc83644907097285396360e9e82e30f81a21e9b1ba836a3e"
 dependencies = [
  "byteorder",
  "gltf-json",
@@ -1566,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "gltf-derive"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a9333e0f9c7bca94dfc20bcf44fa12a61eeec662d6e007563ff748aa59c70"
+checksum = "bdd53d6e284bb2bf02a6926e4cc4984978c1990914d6cd9deae4e31cf37cd113"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -1578,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "gltf-json"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1414d3a98cbaabdb2f134328b1f6036d14b282febc1df51952a435d2ca17fb6"
+checksum = "9949836a9ec5e7f83f76fb9bbcbc77f254a577ebbdb0820867bc11979ef97cad"
 dependencies = [
  "gltf-derive",
  "serde",
@@ -1655,6 +1692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
+ "serde",
 ]
 
 [[package]]
@@ -1674,9 +1712,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexasphere"
-version = "6.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b219bdb56b14905fa5429636bfc4df0043626642d4586d069a82019130846f5"
+checksum = "04ab9d20ba513ff1582a7d885e91839f62cf28bef7c56b1b0428ca787315979b"
 dependencies = [
  "glam",
  "lazy_static",
@@ -2682,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d98f5e557b61525057e2bc142c8cd7f0e70d75dc32852309bec440e6e046bf9"
+checksum = "ec0939e9f626e6c6f1989adb6226a039c855ca483053f0ee7c98b90e41cf731e"
 dependencies = [
  "cpal",
  "lewton",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ bevy_renderer = [
 ]
 
 [dependencies]
-bevy = { version = "0.6.1", optional = true }
+bevy = { version = "0.7.0", optional = true }
 bevy_kayak_ui = { path = "bevy_kayak_ui", optional = true }
 kayak_core = { path = "kayak_core" }
 kayak_font = { path = "kayak_font" }
 kayak_render_macros = { path = "kayak_render_macros" }
 
 [dev-dependencies]
-bevy = { version = "0.6.1" }
+bevy = { version = "0.7.0" }
 rand = { version = "0.8.4" }
 
 [[example]]

--- a/bevy_kayak_renderer/Cargo.toml
+++ b/bevy_kayak_renderer/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bytemuck = "1.7.2"
-bevy = { version = "0.6.1" }
+bevy = { version = "0.7.0" }
 kayak_font = { path = "../kayak_font" }
 serde = "1.0"
 serde_json = "1.0"

--- a/bevy_kayak_renderer/src/camera/camera.rs
+++ b/bevy_kayak_renderer/src/camera/camera.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Bundle, GlobalTransform, Transform},
+    prelude::{Bundle, GlobalTransform, Transform, Component},
     render::{
         camera::{Camera, CameraProjection, DepthCalculation, WindowOrigin},
         primitives::Frustum,
@@ -9,6 +9,9 @@ use bevy::{
 
 use super::ortho::UIOrthographicProjection;
 
+#[derive(Component, Default)]
+pub struct CameraUiKayak;
+
 #[derive(Bundle)]
 pub struct UICameraBundle {
     pub camera: Camera,
@@ -17,6 +20,7 @@ pub struct UICameraBundle {
     pub frustum: Frustum,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    pub marker: CameraUiKayak
 }
 
 impl UICameraBundle {
@@ -44,15 +48,13 @@ impl UICameraBundle {
             orthographic_projection.far(),
         );
         UICameraBundle {
-            camera: Camera {
-                name: Some(Self::UI_CAMERA.to_string()),
-                ..Default::default()
-            },
+            camera: Default::default(),
             orthographic_projection,
             frustum,
             visible_entities: VisibleEntities::default(),
             transform,
             global_transform: Default::default(),
+            marker: CameraUiKayak
         }
     }
 }

--- a/bevy_kayak_renderer/src/camera/camera.rs
+++ b/bevy_kayak_renderer/src/camera/camera.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Bundle, GlobalTransform, Transform, Component},
+    prelude::{Bundle, Component, GlobalTransform, Transform},
     render::{
         camera::{Camera, CameraProjection, DepthCalculation, WindowOrigin},
         primitives::Frustum,
@@ -20,7 +20,7 @@ pub struct UICameraBundle {
     pub frustum: Frustum,
     pub transform: Transform,
     pub global_transform: GlobalTransform,
-    pub marker: CameraUiKayak
+    pub marker: CameraUiKayak,
 }
 
 impl UICameraBundle {
@@ -54,7 +54,7 @@ impl UICameraBundle {
             visible_entities: VisibleEntities::default(),
             transform,
             global_transform: Default::default(),
-            marker: CameraUiKayak
+            marker: CameraUiKayak,
         }
     }
 }

--- a/bevy_kayak_renderer/src/camera/mod.rs
+++ b/bevy_kayak_renderer/src/camera/mod.rs
@@ -13,8 +13,6 @@ pub struct KayakUICameraPlugin;
 
 impl Plugin for KayakUICameraPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        // let mut active_cameras = app.world.get_resource_mut::<ActiveCameras>().unwrap();
-        // active_cameras.add(UICameraBundle::UI_CAMERA);
         app.add_system_to_stage(
             CoreStage::PostUpdate,
             bevy::render::camera::camera_system::<UIOrthographicProjection>,

--- a/bevy_kayak_renderer/src/camera/mod.rs
+++ b/bevy_kayak_renderer/src/camera/mod.rs
@@ -1,12 +1,12 @@
 use bevy::{
     prelude::{CoreStage, Plugin},
-    render::camera::{CameraTypePlugin},
+    render::camera::CameraTypePlugin,
 };
 
 mod camera;
 mod ortho;
 
-pub use camera::{UICameraBundle,CameraUiKayak};
+pub use camera::{CameraUiKayak, UICameraBundle};
 pub(crate) use ortho::UIOrthographicProjection;
 
 pub struct KayakUICameraPlugin;

--- a/bevy_kayak_renderer/src/camera/mod.rs
+++ b/bevy_kayak_renderer/src/camera/mod.rs
@@ -1,23 +1,24 @@
 use bevy::{
     prelude::{CoreStage, Plugin},
-    render::camera::ActiveCameras,
+    render::camera::{CameraTypePlugin},
 };
 
 mod camera;
 mod ortho;
 
-pub use camera::UICameraBundle;
+pub use camera::{UICameraBundle,CameraUiKayak};
 pub(crate) use ortho::UIOrthographicProjection;
 
 pub struct KayakUICameraPlugin;
 
 impl Plugin for KayakUICameraPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        let mut active_cameras = app.world.get_resource_mut::<ActiveCameras>().unwrap();
-        active_cameras.add(UICameraBundle::UI_CAMERA);
+        // let mut active_cameras = app.world.get_resource_mut::<ActiveCameras>().unwrap();
+        // active_cameras.add(UICameraBundle::UI_CAMERA);
         app.add_system_to_stage(
             CoreStage::PostUpdate,
             bevy::render::camera::camera_system::<UIOrthographicProjection>,
-        );
+        )
+        .add_plugin(CameraTypePlugin::<CameraUiKayak>::default());
     }
 }

--- a/bevy_kayak_renderer/src/render/mod.rs
+++ b/bevy_kayak_renderer/src/render/mod.rs
@@ -2,7 +2,7 @@ use bevy::{
     core_pipeline::node::MAIN_PASS_DRIVER,
     prelude::{Commands, Plugin, Res},
     render::{
-        camera::ActiveCameras,
+        camera::ActiveCamera,
         render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
         render_phase::{DrawFunctions, RenderPhase},
         RenderApp, RenderStage,
@@ -13,7 +13,7 @@ use crate::{
     render::{
         ui_pass::MainPassUINode, ui_pass_driver::UIPassDriverNode, unified::UnifiedRenderPlugin,
     },
-    UICameraBundle,
+    CameraUiKayak,
 };
 
 use self::ui_pass::TransparentUI;
@@ -81,13 +81,11 @@ impl Plugin for BevyKayakUIRenderPlugin {
 
 pub fn extract_core_pipeline_camera_phases(
     mut commands: Commands,
-    active_cameras: Res<ActiveCameras>,
+    active_camera: Res<ActiveCamera<CameraUiKayak>>,
 ) {
-    if let Some(camera_2d) = active_cameras.get(UICameraBundle::UI_CAMERA) {
-        if let Some(entity) = camera_2d.entity {
-            commands
-                .get_or_spawn(entity)
-                .insert(RenderPhase::<TransparentUI>::default());
-        }
+    if let Some(entity) = active_camera.get() {
+        commands
+            .get_or_spawn(entity)
+            .insert(RenderPhase::<TransparentUI>::default());
     }
 }

--- a/bevy_kayak_renderer/src/render/ui_pass.rs
+++ b/bevy_kayak_renderer/src/render/ui_pass.rs
@@ -1,7 +1,7 @@
 use bevy::core::FloatOrd;
 use bevy::ecs::prelude::*;
 use bevy::render::render_phase::{DrawFunctionId, PhaseItem};
-use bevy::render::render_resource::{CachedPipelineId, RenderPassColorAttachment};
+use bevy::render::render_resource::{CachedRenderPipelineId, RenderPassColorAttachment};
 use bevy::render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
@@ -13,7 +13,7 @@ use bevy::render::{
 pub struct TransparentUI {
     pub sort_key: FloatOrd,
     pub entity: Entity,
-    pub pipeline: CachedPipelineId,
+    pub pipeline: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
 }
 

--- a/bevy_kayak_renderer/src/render/ui_pass_driver.rs
+++ b/bevy_kayak_renderer/src/render/ui_pass_driver.rs
@@ -1,11 +1,10 @@
-use bevy::ecs::world::World;
+use bevy::{ecs::world::World, render::camera::ActiveCamera};
 use bevy::render::{
-    camera::ExtractedCameraNames,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotValue},
     renderer::RenderContext,
 };
 
-use crate::UICameraBundle;
+use crate::CameraUiKayak;
 
 pub struct UIPassDriverNode;
 
@@ -16,11 +15,10 @@ impl Node for UIPassDriverNode {
         _render_context: &mut RenderContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
-        let extracted_cameras = world.get_resource::<ExtractedCameraNames>().unwrap();
-        if let Some(camera_ui) = extracted_cameras.entities.get(UICameraBundle::UI_CAMERA) {
+        if let Some(camera_ui) = world.resource::<ActiveCamera<CameraUiKayak>>().get() {
             graph.run_sub_graph(
                 super::draw_ui_graph::NAME,
-                vec![SlotValue::Entity(*camera_ui)],
+                vec![SlotValue::Entity(camera_ui)],
             )?;
         }
 

--- a/bevy_kayak_renderer/src/render/ui_pass_driver.rs
+++ b/bevy_kayak_renderer/src/render/ui_pass_driver.rs
@@ -1,8 +1,8 @@
-use bevy::{ecs::world::World, render::camera::ActiveCamera};
 use bevy::render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotValue},
     renderer::RenderContext,
 };
+use bevy::{ecs::world::World, render::camera::ActiveCamera};
 
 use crate::CameraUiKayak;
 

--- a/bevy_kayak_renderer/src/render/unified/pipeline.rs
+++ b/bevy_kayak_renderer/src/render/unified/pipeline.rs
@@ -17,8 +17,8 @@ use bevy::{
             BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingResource, BindingType,
             BlendComponent, BlendFactor, BlendOperation, BlendState, BufferBindingType, BufferSize,
             BufferUsages, BufferVec, CachedRenderPipelineId, ColorTargetState, ColorWrites,
-            DynamicUniformVec, Extent3d, FragmentState, FrontFace, MultisampleState, PolygonMode,
-            PrimitiveState, PrimitiveTopology, PipelineCache, RenderPipelineDescriptor,
+            DynamicUniformVec, Extent3d, FragmentState, FrontFace, MultisampleState, PipelineCache,
+            PolygonMode, PrimitiveState, PrimitiveTopology, RenderPipelineDescriptor,
             SamplerBindingType, SamplerDescriptor, Shader, ShaderStages, TextureDescriptor,
             TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
             TextureViewDescriptor, TextureViewDimension, VertexAttribute, VertexBufferLayout,
@@ -269,7 +269,7 @@ impl FromWorld for UnifiedPipeline {
                 width: 1.0,
                 height: 1.0,
             },
-            texture_format: TextureFormat::Rgba8UnormSrgb
+            texture_format: TextureFormat::Rgba8UnormSrgb,
         };
 
         let binding = render_device.create_bind_group(&BindGroupDescriptor {

--- a/bevy_kayak_ui/Cargo.toml
+++ b/bevy_kayak_ui/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bytemuck = "1.7.2"
-bevy = { version = "0.6.1" }
+bevy = { version = "0.7.0" }
 kayak_core = { path = "../kayak_core" }
 kayak_font = { path = "../kayak_font" }
 bevy_kayak_renderer = { path = "../bevy_kayak_renderer" }

--- a/kayak_core/Cargo.toml
+++ b/kayak_core/Cargo.toml
@@ -11,7 +11,7 @@ bevy_renderer = ["bevy", "kayak_font/bevy_renderer"]
 
 [dependencies]
 as-any = "0.2"
-bevy = { version = "0.6.1", optional = true }
+bevy = { version = "0.7.0", optional = true }
 desync = { version = "0.7" }
 flo_rope = { version = "0.1" }
 futures = { version = "0.3" }

--- a/kayak_font/Cargo.toml
+++ b/kayak_font/Cargo.toml
@@ -11,7 +11,7 @@ bevy_renderer = ["bevy"]
 
 [dependencies]
 anyhow = { version = "1.0" }
-bevy = { version = "0.6.1", optional = true }
+bevy = { version = "0.7.0", optional = true }
 bytemuck = "1.7.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kayak_font/src/renderer/font_texture_cache.rs
+++ b/kayak_font/src/renderer/font_texture_cache.rs
@@ -154,7 +154,7 @@ impl FontTextureCache {
                 width: size.0 as f32,
                 height: size.1 as f32,
             },
-            texture_format: format
+            texture_format: format,
         };
 
         images.insert(font_handle, image);
@@ -199,7 +199,7 @@ impl FontTextureCache {
                 width: 1.0,
                 height: 1.0,
             },
-            texture_format: TextureFormat::Rgba8Unorm
+            texture_format: TextureFormat::Rgba8Unorm,
         };
 
         let binding = device.create_bind_group(&BindGroupDescriptor {

--- a/kayak_font/src/renderer/font_texture_cache.rs
+++ b/kayak_font/src/renderer/font_texture_cache.rs
@@ -154,6 +154,7 @@ impl FontTextureCache {
                 width: size.0 as f32,
                 height: size.1 as f32,
             },
+            texture_format: format
         };
 
         images.insert(font_handle, image);
@@ -198,6 +199,7 @@ impl FontTextureCache {
                 width: 1.0,
                 height: 1.0,
             },
+            texture_format: TextureFormat::Rgba8Unorm
         };
 
         let binding = device.create_bind_group(&BindGroupDescriptor {


### PR DESCRIPTION
- [x] `GpuImage` requires `texture_format` now.
- [x] `ActiveCameras` was removed
  - https://github.com/bevyengine/bevy/commit/bf6de8962287050369cd98605490bdd7770c87b4
- [x] `CachedPipelineId` is now `CachedRenderPipelineId` and renamed `RenderPipelineCache` to `PipelineCache`
  - https://github.com/bevyengine/bevy/pull/3979

~~I started working on the camera marker changes but I don't understand the changes well enough to do it yet, so I handled the other changes in the meantime.~~

There are some failing tests, but they seem to also be failing on the main branch. I ran some examples and full_ui, counter, and tabs are all working with these changes.
<img width="1382" alt="Screen Shot 2022-04-17 at 7 13 16 AM" src="https://user-images.githubusercontent.com/551247/163718388-bdb88056-d558-47d8-bff7-1e8d91e92eee.png">
<img width="740" alt="Screen Shot 2022-04-17 at 7 13 36 AM" src="https://user-images.githubusercontent.com/551247/163718389-0dfac7b6-a912-40dc-bdce-41c0a2d5c09b.png">
<img width="1382" alt="Screen Shot 2022-04-17 at 7 13 51 AM" src="https://user-images.githubusercontent.com/551247/163718391-9e3b1301-022a-4c88-b0c8-fc853dcb50b1.png">

