### PR TITLE
Fix `DownwardIterator`

### DIFF
--- a/kayak_core/src/focus_tree.rs
+++ b/kayak_core/src/focus_tree.rs
@@ -245,8 +245,7 @@ mod tests {
         focus_tree.add(a_a_a_b, &tree);
         focus_tree.add(a_b_a, &tree);
 
-        assert_eq!(None, focus_tree.current_focus);
-        assert_eq!(Some(a), focus_tree.next());
+        assert_eq!(Some(a), focus_tree.current_focus);
         assert_eq!(Some(a_a), focus_tree.next());
         assert_eq!(Some(a_a_a), focus_tree.next());
         assert_eq!(Some(a_a_a_a), focus_tree.next());
@@ -288,8 +287,7 @@ mod tests {
         focus_tree.add(a_a_a_b, &tree);
         focus_tree.add(a_b_a, &tree);
 
-        assert_eq!(None, focus_tree.current_focus);
-        assert_eq!(Some(a), focus_tree.prev());
+        assert_eq!(Some(a), focus_tree.current_focus);
         assert_eq!(Some(a_b_a), focus_tree.prev());
         assert_eq!(Some(a_b), focus_tree.prev());
         assert_eq!(Some(a_a_a_b), focus_tree.prev());

--- a/kayak_core/src/tree.rs
+++ b/kayak_core/src/tree.rs
@@ -1,8 +1,8 @@
+use std::iter::Rev;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
-use std::iter::Rev;
 
 use morphorm::Hierarchy;
 
@@ -346,8 +346,8 @@ impl Tree {
                     let parent_b = parent_b.unwrap();
                     parent_a != parent_b
                         || (parent_a == parent_b
-                        && *node != children_a.get(*id).unwrap().1
-                        && children_a.iter().any(|(_, node_b)| node == node_b))
+                            && *node != children_a.get(*id).unwrap().1
+                            && children_a.iter().any(|(_, node_b)| node == node_b))
                 } else {
                     false
                 };
@@ -468,8 +468,8 @@ impl Tree {
                     let parent_b = parent_b.unwrap();
                     parent_a != parent_b
                         || (parent_a == parent_b
-                        && *node != tree1.get(*id).unwrap().1
-                        && tree1.iter().any(|(_, node_b)| node == node_b))
+                            && *node != tree1.get(*id).unwrap().1
+                            && tree1.iter().any(|(_, node_b)| node == node_b))
                 } else {
                     false
                 };
@@ -632,7 +632,12 @@ impl<'a> DownwardIterator<'a> {
     /// [tree]: Tree
     /// [node]: Index
     pub fn new(tree: &'a Tree, starting_node: Option<Index>, include_self: bool) -> Self {
-        Self { tree, starting_node, current_node: starting_node, include_self }
+        Self {
+            tree,
+            starting_node,
+            current_node: starting_node,
+            include_self,
+        }
     }
 }
 
@@ -666,7 +671,7 @@ impl<'a> Iterator for DownwardIterator<'a> {
                     }
                     if let Some(current_parent) = current_parent {
                         if let Some(next_parent_sibling) =
-                        self.tree.get_next_sibling(current_parent)
+                            self.tree.get_next_sibling(current_parent)
                         {
                             // Continue from the sibling of the parent
                             self.current_node = Some(next_parent_sibling);
@@ -704,7 +709,11 @@ impl<'a> UpwardIterator<'a> {
     /// [tree]: Tree
     /// [node]: Index
     pub fn new(tree: &'a Tree, starting_node: Option<Index>, include_self: bool) -> Self {
-        Self { tree, current_node: starting_node, include_self }
+        Self {
+            tree,
+            current_node: starting_node,
+            include_self,
+        }
     }
 }
 
@@ -824,8 +833,8 @@ impl WidgetTree {
 #[cfg(test)]
 mod tests {
     use crate::node::NodeBuilder;
-    use crate::{Arena, Index, Tree};
     use crate::tree::{DownwardIterator, UpwardIterator};
+    use crate::{Arena, Index, Tree};
 
     #[test]
     fn test_tree() {

--- a/kayak_core/src/tree.rs
+++ b/kayak_core/src/tree.rs
@@ -610,6 +610,8 @@ impl Tree {
     }
 }
 
+/// An iterator that performs a depth-first traversal down a tree starting
+/// from a given node.
 pub struct DownwardIterator<'a> {
     tree: &'a Tree,
     starting_node: Option<Index>,
@@ -618,6 +620,17 @@ pub struct DownwardIterator<'a> {
 }
 
 impl<'a> DownwardIterator<'a> {
+    /// Creates a new [`DownwardIterator`] for the given [tree] and [node].
+    ///
+    /// # Arguments
+    ///
+    /// * `tree`: The tree to be iterated.
+    /// * `starting_node`: The node to start iterating from.
+    /// * `include_self`: Whether or not to include the starting node in the output.
+    ///
+    ///
+    /// [tree]: Tree
+    /// [node]: Index
     pub fn new(tree: &'a Tree, starting_node: Option<Index>, include_self: bool) -> Self {
         Self { tree, starting_node, current_node: starting_node, include_self }
     }
@@ -634,36 +647,44 @@ impl<'a> Iterator for DownwardIterator<'a> {
 
         if let Some(current_index) = self.current_node {
             if let Some(first_child) = self.tree.get_first_child(current_index) {
+                // Descend!
                 self.current_node = Some(first_child);
                 return Some(first_child);
             } else if let Some(next_sibling) = self.tree.get_next_sibling(current_index) {
+                // Continue from the next sibling
                 self.current_node = Some(next_sibling);
                 return Some(next_sibling);
             } else if self.current_node == self.starting_node {
+                // We've somehow made our way back up to the starting node -> end iteration
                 return None;
             } else {
                 let mut current_parent = self.tree.get_parent(current_index);
                 while current_parent.is_some() {
                     if current_parent == self.starting_node {
+                        // Parent is starting node so no need to continue -> end iteration
                         return None;
                     }
                     if let Some(current_parent) = current_parent {
                         if let Some(next_parent_sibling) =
                         self.tree.get_next_sibling(current_parent)
                         {
+                            // Continue from the sibling of the parent
                             self.current_node = Some(next_parent_sibling);
                             return Some(next_parent_sibling);
                         }
                     }
+                    // Go back up the tree to find the next available node
                     current_parent = self.tree.get_parent(current_parent.unwrap());
                 }
             }
         }
 
-        return None;
+        return self.current_node;
     }
 }
 
+/// An iterator that performs a single-path traversal up a tree starting
+/// from a given node.
 pub struct UpwardIterator<'a> {
     tree: &'a Tree,
     current_node: Option<Index>,
@@ -671,6 +692,17 @@ pub struct UpwardIterator<'a> {
 }
 
 impl<'a> UpwardIterator<'a> {
+    /// Creates a new [`UpwardIterator`] for the given [tree] and [node].
+    ///
+    /// # Arguments
+    ///
+    /// * `tree`: The tree to be iterated.
+    /// * `starting_node`: The node to start iterating from.
+    /// * `include_self`: Whether or not to include the starting node in the output.
+    ///
+    ///
+    /// [tree]: Tree
+    /// [node]: Index
     pub fn new(tree: &'a Tree, starting_node: Option<Index>, include_self: bool) -> Self {
         Self { tree, current_node: starting_node, include_self }
     }


### PR DESCRIPTION
## Objective

Using `DownwardIterator` resulted in output that I don't think is intended. For example, take the following tree:

```
    A
   / \
  B   C
 /\   |
D  E  F
|
G 
```

Using `DownwardIterator` on node B, should result in `[B, D, G, E]` but ended up returning `[B, D, G, E, C, F]`. It was moving to the next sibling in the list.

> This probably went unnoticed due to the fact we only used it for iterating down from the root node, which has no siblings.

## Solution

Fixed up `DownwardIterator` to not go beyond its starting node.

### Additional Changes

* Added a public constructor to `DownwardIterator`
* `Tree::flatten()` now only used for `Hierarchy::up_iter()`
* Re-instated `UpwardIterator` (not used within `Hierarchy` though)
* Slightly improved docs
* Added tests