### PR TITLE
kayak_core: Improve `Tree` methods

### DIFF
--- a/kayak_core/src/context.rs
+++ b/kayak_core/src/context.rs
@@ -591,9 +591,9 @@ impl KayakContext {
 
     #[allow(dead_code)]
     fn get_all_parents(&self, current: Index, parents: &mut Vec<Index>) {
-        if let Some(parent) = self.widget_manager.tree.parents.get(&current) {
-            parents.push(*parent);
-            self.get_all_parents(*parent, parents);
+        if let Some(parent) = self.widget_manager.tree.get_parent(current) {
+            parents.push(parent);
+            self.get_all_parents(parent, parents);
         }
     }
 

--- a/kayak_core/src/event_dispatcher.rs
+++ b/kayak_core/src/event_dispatcher.rs
@@ -253,7 +253,7 @@ impl EventDispatcher {
         let mut event_stream = Vec::<Event>::new();
         let mut states: HashMap<EventType, EventState> = HashMap::new();
 
-        let root = if let Some(root) = widget_manager.node_tree.root_node {
+        let root = if let Some(root) = widget_manager.node_tree.root() {
             root
         } else {
             return event_stream;
@@ -351,7 +351,7 @@ impl EventDispatcher {
 
                 // --- Push Children to Stack --- //
                 if enter_children {
-                    if let Some(children) = widget_manager.node_tree.children.get(&current) {
+                    if let Some(children) = widget_manager.node_tree.get_children(current) {
                         for child in children {
                             stack.push((*child, depth + 1));
                         }

--- a/kayak_core/src/focus_tree.rs
+++ b/kayak_core/src/focus_tree.rs
@@ -36,7 +36,7 @@ impl FocusTree {
             }
         }
 
-        if self.tree.root_node.is_none() {
+        if self.tree.root().is_none() {
             // Set root node
             self.tree.add(index, None);
             self.focus(index);
@@ -49,7 +49,7 @@ impl FocusTree {
             self.blur();
         }
 
-        if self.tree.root_node == Some(index) {
+        if self.tree.root() == Some(index) {
             self.tree.remove(index);
         } else {
             self.tree.remove_and_reparent(index);
@@ -76,7 +76,7 @@ impl FocusTree {
     ///
     /// This returns focus to the root node
     pub fn blur(&mut self) {
-        self.current_focus = self.tree.root_node;
+        self.current_focus = self.tree.root();
     }
 
     /// Get the currently focused index
@@ -120,7 +120,7 @@ impl FocusTree {
         }
 
         // Default to root node to begin the cycle again
-        self.tree.root_node
+        self.tree.root()
     }
 
     /// Peek the previous focusable index without actually changing focus
@@ -149,7 +149,7 @@ impl FocusTree {
             return Some(next);
         }
 
-        self.tree.root_node
+        self.tree.root()
     }
 
     pub fn tree(&self) -> &Tree {

--- a/kayak_core/src/tree.rs
+++ b/kayak_core/src/tree.rs
@@ -1189,6 +1189,58 @@ mod tests {
     }
 
     #[test]
+    fn should_recalculate_depths() {
+        let a = Index::from_raw_parts(0, 0);
+        let b = Index::from_raw_parts(1, 0);
+        let c = Index::from_raw_parts(2, 0);
+        let d = Index::from_raw_parts(3, 0);
+
+        let mut expected = Tree::default();
+        expected.add(a, None);
+        expected.add(b, Some(a));
+        expected.add(c, Some(b));
+        expected.add(d, Some(c));
+
+        // Test: Reverse-insertion order and recalculate from root
+        let mut tree = Tree::default();
+        tree.add(c, Some(b));
+        tree.add(b, Some(a));
+        tree.add(d, Some(c));
+        tree.add(a, None);
+
+        assert_eq!(expected.root_node, tree.root_node);
+        assert_eq!(expected.parents, tree.parents);
+        assert_eq!(expected.children, tree.children);
+        assert_ne!(expected.depths, tree.depths);
+
+        tree.recalculate_depths(None);
+
+        assert_eq!(expected.root_node, tree.root_node);
+        assert_eq!(expected.parents, tree.parents);
+        assert_eq!(expected.children, tree.children);
+        assert_eq!(expected.depths, tree.depths);
+
+        // Test: Swapped insertions and recalculate from parent
+        let mut tree = Tree::default();
+        tree.add(a, None);
+        tree.add(b, Some(a));
+        tree.add(d, Some(c));
+        tree.add(c, Some(b));
+
+        assert_eq!(expected.root_node, tree.root_node);
+        assert_eq!(expected.parents, tree.parents);
+        assert_eq!(expected.children, tree.children);
+        assert_ne!(expected.depths, tree.depths);
+
+        tree.recalculate_depths(Some(b));
+
+        assert_eq!(expected.root_node, tree.root_node);
+        assert_eq!(expected.parents, tree.parents);
+        assert_eq!(expected.children, tree.children);
+        assert_eq!(expected.depths, tree.depths);
+    }
+
+    #[test]
     fn should_have_correct_depth() {
         let mut tree = Tree::default();
 

--- a/kayak_core/src/tree.rs
+++ b/kayak_core/src/tree.rs
@@ -1,9 +1,9 @@
+use std::cmp::Ordering;
 use std::iter::Rev;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
-use std::cmp::Ordering;
 
 use morphorm::Hierarchy;
 
@@ -83,7 +83,10 @@ impl Tree {
     ///
     /// Panics if the given parent node does not already exist within the tree.
     pub fn add_children(&mut self, children: Vec<Index>, parent: Index) {
-        assert!(self.contains(parent), "parent should exist in the tree before adding children");
+        assert!(
+            self.contains(parent),
+            "parent should exist in the tree before adding children"
+        );
 
         let parent_depth = self.depths.get(&parent).copied().unwrap_or_default();
         for child in children.iter() {
@@ -349,7 +352,10 @@ impl Tree {
         }
 
         // Unreachable since we already check that they exist in the same tree (i.e. always share the root node in common)
-        unreachable!("nodes `{:?}` and `{:?}` do not share a common ancestor— but definitely should!", a, b);
+        unreachable!(
+            "nodes `{:?}` and `{:?}` do not share a common ancestor— but definitely should!",
+            a, b
+        );
     }
 
     pub fn flatten(&self) -> Vec<Index> {
@@ -417,7 +423,10 @@ impl Tree {
         }
 
         // Unreachable since we already check that they exist in the same tree (i.e. always share the root node in common)
-        unreachable!("nodes `{:?}` and `{:?}` do not share a common ancestor— but definitely should!", a, b);
+        unreachable!(
+            "nodes `{:?}` and `{:?}` do not share a common ancestor— but definitely should!",
+            a, b
+        );
     }
 
     /// Get the parent of the given node.
@@ -433,12 +442,17 @@ impl Tree {
     ///
     /// Returns `None` if the node is not part of this tree or it contains no children.
     pub fn get_children(&self, index: Index) -> Option<&[Index]> {
-        self.children.get(&index).map(|children| children.as_slice())
+        self.children
+            .get(&index)
+            .map(|children| children.as_slice())
     }
 
     /// Returns the total number of children for a given node.
     pub fn child_count(&self, index: Index) -> usize {
-        self.children.get(&index).map(|children| children.len()).unwrap_or_default()
+        self.children
+            .get(&index)
+            .map(|children| children.len())
+            .unwrap_or_default()
     }
 
     /// Get the child at an offset within the given node's children.
@@ -446,7 +460,9 @@ impl Tree {
     /// Returns `None` if the node is not part of this tree, it contains no children,
     /// or the offset is out of bounds.
     pub fn get_child_at(&self, index: Index, offset: usize) -> Option<Index> {
-        self.children.get(&index).map(|children| children.get(offset).copied())?
+        self.children
+            .get(&index)
+            .map(|children| children.get(offset).copied())?
     }
 
     /// Get the order of a node among its siblings.
@@ -456,8 +472,14 @@ impl Tree {
     /// to check if the tree contains a node.
     pub fn get_sibling_order(&self, index: Index) -> usize {
         if let Some(parent) = self.get_parent(index) {
-            self.children.get(&parent)
-                .map(|children| children.iter().position(|child| *child == index).unwrap_or_default())
+            self.children
+                .get(&parent)
+                .map(|children| {
+                    children
+                        .iter()
+                        .position(|child| *child == index)
+                        .unwrap_or_default()
+                })
                 .unwrap_or_default()
         } else {
             0
@@ -615,8 +637,8 @@ impl Tree {
                     let parent_b = parent_b.unwrap();
                     parent_a != parent_b
                         || (parent_a == parent_b
-                        && *node != children_a.get(*id).unwrap().1
-                        && children_a.iter().any(|(_, node_b)| node == node_b))
+                            && *node != children_a.get(*id).unwrap().1
+                            && children_a.iter().any(|(_, node_b)| node == node_b))
                 } else {
                     false
                 };
@@ -737,8 +759,8 @@ impl Tree {
                     let parent_b = parent_b.unwrap();
                     parent_a != parent_b
                         || (parent_a == parent_b
-                        && *node != tree1.get(*id).unwrap().1
-                        && tree1.iter().any(|(_, node_b)| node == node_b))
+                            && *node != tree1.get(*id).unwrap().1
+                            && tree1.iter().any(|(_, node_b)| node == node_b))
                 } else {
                     false
                 };
@@ -880,7 +902,12 @@ impl Tree {
     }
 
     /// Recursively updates the depths of a given node and its children.
-    fn update_depths(depths: &mut HashMap<Index, usize>, children: &HashMap<Index, Vec<Index>>, index: Index, depth: usize) {
+    fn update_depths(
+        depths: &mut HashMap<Index, usize>,
+        children: &HashMap<Index, Vec<Index>>,
+        index: Index,
+        depth: usize,
+    ) {
         depths.insert(index, depth);
         if let Some(childs) = children.get(&index) {
             for child in childs {
@@ -951,7 +978,7 @@ impl<'a> Iterator for DownwardIterator<'a> {
                     }
                     if let Some(current_parent) = current_parent {
                         if let Some(next_parent_sibling) =
-                        self.tree.get_next_sibling(current_parent)
+                            self.tree.get_next_sibling(current_parent)
                         {
                             // Continue from the sibling of the parent
                             self.current_node = Some(next_parent_sibling);
@@ -1112,10 +1139,10 @@ impl WidgetTree {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Ordering;
     use crate::node::NodeBuilder;
     use crate::tree::{DownwardIterator, UpwardIterator};
     use crate::{Arena, Index, Tree};
+    use std::cmp::Ordering;
 
     #[test]
     fn test_tree() {
@@ -1576,7 +1603,6 @@ mod tests {
         tree.add(g, Some(d));
         tree.add(f, Some(c));
 
-
         let common_ancestor = tree.get_common_ancestor(d, e);
         assert_eq!(Some(b), common_ancestor, "D and E should share B in common");
         let common_ancestor = tree.get_common_ancestor(e, d);
@@ -1599,7 +1625,10 @@ mod tests {
 
         let z = Index::from_raw_parts(123, 0);
         let common_ancestor = tree.get_common_ancestor(a, z);
-        assert_eq!(None, common_ancestor, "A and Z should share nothing in common");
+        assert_eq!(
+            None, common_ancestor,
+            "A and Z should share nothing in common"
+        );
     }
 
     #[test]
@@ -1631,21 +1660,32 @@ mod tests {
         tree.add(g, Some(d));
         tree.add(f, Some(c));
 
-
         let ordering = tree.partial_cmp(d, e);
         assert_eq!(Some(Ordering::Less), ordering, "D should be less than E");
         let ordering = tree.partial_cmp(e, d);
-        assert_eq!(Some(Ordering::Greater), ordering, "E should be greater than D");
+        assert_eq!(
+            Some(Ordering::Greater),
+            ordering,
+            "E should be greater than D"
+        );
 
         let ordering = tree.partial_cmp(d, g);
         assert_eq!(Some(Ordering::Less), ordering, "D should be less than G");
         let ordering = tree.partial_cmp(g, d);
-        assert_eq!(Some(Ordering::Greater), ordering, "G should be greater than D");
+        assert_eq!(
+            Some(Ordering::Greater),
+            ordering,
+            "G should be greater than D"
+        );
 
         let ordering = tree.partial_cmp(g, f);
         assert_eq!(Some(Ordering::Less), ordering, "G should be less than F");
         let ordering = tree.partial_cmp(f, g);
-        assert_eq!(Some(Ordering::Greater), ordering, "F should be greater than G");
+        assert_eq!(
+            Some(Ordering::Greater),
+            ordering,
+            "F should be greater than G"
+        );
 
         let ordering = tree.partial_cmp(a, a);
         assert_eq!(Some(Ordering::Equal), ordering, "A should be equal to A");

--- a/kayak_core/src/tree.rs
+++ b/kayak_core/src/tree.rs
@@ -501,38 +501,22 @@ impl Tree {
     }
 
     pub fn get_next_sibling(&self, index: Index) -> Option<Index> {
-        if let Some(parent_index) = self.get_parent(index) {
-            self.children.get(&parent_index).map_or(None, |children| {
-                children
-                    .iter()
-                    .position(|child| *child == index)
-                    .map_or(None, |child_index| {
-                        children
-                            .get(child_index + 1)
-                            .map_or(None, |next_child| Some(*next_child))
-                    })
-            })
+        let order = self.get_sibling_order(index);
+        if let Some(children) = self.get_children(index) {
+            children.get(order + 1).map(|sibling| *sibling)
         } else {
             None
         }
     }
 
     pub fn get_prev_sibling(&self, index: Index) -> Option<Index> {
-        if let Some(parent_index) = self.get_parent(index) {
-            self.children.get(&parent_index).map_or(None, |children| {
-                children
-                    .iter()
-                    .position(|child| *child == index)
-                    .map_or(None, |child_index| {
-                        if child_index > 0 {
-                            children
-                                .get(child_index - 1)
-                                .map_or(None, |prev_child| Some(*prev_child))
-                        } else {
-                            None
-                        }
-                    })
-            })
+        let order = self.get_sibling_order(index);
+        if order == 0 {
+            return None;
+        }
+
+        if let Some(children) = self.get_children(index) {
+            children.get(order - 1).map(|sibling| *sibling)
         } else {
             None
         }

--- a/kayak_core/src/widget_manager.rs
+++ b/kayak_core/src/widget_manager.rs
@@ -220,8 +220,7 @@ impl WidgetManager {
                 };
 
             // Get parent Z
-            let parent_z = if let Some(parent_widget_id) = self.tree.get_parent(dirty_node_index)
-            {
+            let parent_z = if let Some(parent_widget_id) = self.tree.get_parent(dirty_node_index) {
                 if let Some(parent) = &self.nodes[parent_widget_id] {
                     parent.z
                 } else {
@@ -503,8 +502,8 @@ impl WidgetManager {
     /// * `binding`: the binding to watch
     ///
     pub(crate) fn bind<T>(&mut self, id: Index, binding: &Binding<T>)
-        where
-            T: resources::Resource + Clone + PartialEq,
+    where
+        T: resources::Resource + Clone + PartialEq,
     {
         let dirty_nodes = self.dirty_nodes.clone();
         let lifetime = self.widget_lifetimes.entry(id).or_default();


### PR DESCRIPTION
## Objective

While working on creating the text selection API, I found that there were some `Tree` methods that could be very helpful. 

The first was the ability to quickly find a common ancestor between two nodes (turns out I might not need it, but discovered that after implementing it lol).

The second was having a way to distinguish whether a node comes before or after another node. This one is very important as it helps determine which way to iterate through the tree given a range of two nodes.

## Solution

Added a map to store the depth of each node in the tree.

> Originally, these depths were designed to be entirely maintained internally. However, this only worked when nodes were added from top down (which widgets are not). Therefore, the final design here allows nodes to be given invalid depths with the ability to recalculate them at a later time.

This map allows for easy calculations for certain methods, such as finding a common ancestor and determining the "order" of nodes.

Also took this opportunity to clean up `Tree` member access (and add a few missing helper methods). Before, all members of the tree were publicly accessible, which meant that a tree could quite easily fall into an invalid state. Now all members are private and previous usages have been migrated to a public (or crate-level) method.

#### Added `Tree` Methods

##### Accessors

* `pub fn root(&self) -> Option<Index>`

  Returns the current root node.

* `pub fn depth(&self, index: Index) -> usize`

  Returns the depth of a given node.

* `pub fn get_children(&self, index: Index) -> Option<&[Index]>`

  Returns the children of a given node.

* `pub fn get_sibling_order(&self, index: Index) -> usize`

  Returns the index of a node amongst its siblings.

* `pub fn get_child_at(&self, index: Index, offset: usize) -> Option<Index>`

  Returns the child at a given index for a given node.

* `pub fn child_count(&self, index: Index) -> usize`

  Returns the number of children contained by a given node.

##### Utility

* `pub fn partial_cmp(&self, a: Index, b: Index) -> Option<Ordering>`

  Allows for two nodes to be compared to one another. This returns their left-to-right, depth-first traversal order (assuming they are part of the same tree).

* `pub fn get_common_ancestor(&self, a: Index, b: Index) -> Option<Index>`

  Finds the deepest inclusive common ancestor between two nodes (assuming they are part of the same tree).


##### Mutation

* `pub fn recalculate_depths(&mut self, from: Option<Index>)`

  Recalculates the depths of all nodes (from an optional root node).

* `pub fn add_children(&mut self, children: Vec<Index>, parent: Index)`

  Quickly add a set of children.

* `pub(crate) fn insert_direct(&mut self, index: Index, parent: Option<Index>)`

  Crate method for directly inserting a parent. This avoids all other logic normally associated with adding a node.

* `pub(crate) fn insert_children_direct(&mut self, children: Vec<Index>, parent: Index)`
  
  Crate method for directly inserting a set of children. This avoids all other logic normally associated with adding children.