### PR TITLE
Finalize upgrade to bevy 0.7 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Kayak UI is in the very early stages of development. Important features are miss
 <img src="images/screen1.png" alt="Kayak UI" width="600" />
 
 ## Usage
-Use bevy 0.6!
+Use bevy 0.7!
 
 ```rust
 kayak_ui = { git="https://github.com/StarArawn/kayak_ui", rev="{INSERT_COMMIT_SHA_HERE}", features = ["bevy_renderer"] }
-bevy = "0.6.0"
+bevy = "0.7.0"
 ```
 
 ## Declarative


### PR DESCRIPTION
Closes #116 

Everywhere already appears to use bevy 0.7 internally and I have personally used this project in 2 test games with bevy 0.7 with no version specific problems.  All that was left was changing the readme's recommendation.