### PR TITLE
Use full path to Index in macros

### DIFF
--- a/examples/bevy_state.rs
+++ b/examples/bevy_state.rs
@@ -4,9 +4,7 @@ use bevy::{
     DefaultPlugins,
 };
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
-use kayak_ui::core::{
-    render, rsx, widget, Event, EventType, Index, KayakContextRef, KeyCode, OnEvent,
-};
+use kayak_ui::core::{render, rsx, widget, Event, EventType, KayakContextRef, KeyCode, OnEvent};
 use kayak_ui::widgets::{App, Text};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -7,7 +7,6 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, ImageManager, 
 use kayak_ui::core::{
     render,
     styles::{Edge, Style, StyleProp, Units},
-    Index,
 };
 use kayak_ui::widgets::{App, Clip, NinePatch, Text};
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -7,7 +7,7 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{Style, StyleProp, Units},
-    use_state, widget, EventType, Index, OnEvent,
+    use_state, widget, EventType, OnEvent,
 };
 use kayak_ui::widgets::{App, Button, Text, Window};
 

--- a/examples/fold.rs
+++ b/examples/fold.rs
@@ -9,7 +9,7 @@ use kayak_ui::{
     core::{
         render, rsx,
         styles::{Style, StyleProp, Units},
-        use_state, widget, Color, EventType, Handler, Index, OnEvent,
+        use_state, widget, Color, EventType, Handler, OnEvent,
     },
     widgets::{App, Background, Button, Fold, If, Text, Window},
 };

--- a/examples/full_ui.rs
+++ b/examples/full_ui.rs
@@ -7,7 +7,7 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, ImageManager, 
 use kayak_ui::core::{
     render, rsx,
     styles::{Edge, LayoutType, Style, StyleProp, Units},
-    widget, Bound, Children, EventType, Index, MutableBound, OnEvent, WidgetProps,
+    widget, Bound, Children, EventType, MutableBound, OnEvent, WidgetProps,
 };
 use kayak_ui::widgets::{App, NinePatch, Text};
 

--- a/examples/global_counter.rs
+++ b/examples/global_counter.rs
@@ -4,7 +4,7 @@ use bevy::{
     DefaultPlugins,
 };
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
-use kayak_ui::core::{bind, render, rsx, widget, Binding, Bound, Index, MutableBound};
+use kayak_ui::core::{bind, render, rsx, widget, Binding, Bound, MutableBound};
 use kayak_ui::widgets::{App, Text, Window};
 
 #[derive(Clone, PartialEq)]

--- a/examples/hooks.rs
+++ b/examples/hooks.rs
@@ -16,7 +16,7 @@ use bevy::{
 };
 use kayak_ui::{
     bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle},
-    core::{render, rsx, use_effect, use_state, widget, EventType, Index, OnEvent},
+    core::{render, rsx, use_effect, use_state, widget, EventType, OnEvent},
     widgets::{App, Button, Text, Window},
 };
 

--- a/examples/if.rs
+++ b/examples/if.rs
@@ -7,7 +7,7 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{Style, StyleProp, Units},
-    widget, Bound, EventType, Index, MutableBound, OnEvent,
+    widget, Bound, EventType, MutableBound, OnEvent,
 };
 use kayak_ui::widgets::{App, Button, If, Text, Window};
 

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -8,7 +8,6 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, ImageManager, UICameraBundl
 use kayak_ui::core::{
     render,
     styles::{Corner, Style, StyleProp, Units},
-    Index,
 };
 use kayak_ui::widgets::{App, Image};
 

--- a/examples/nine_patch.rs
+++ b/examples/nine_patch.rs
@@ -7,7 +7,6 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, ImageManager, UICameraBundl
 use kayak_ui::core::{
     render,
     styles::{Edge, Style, StyleProp, Units},
-    Index,
 };
 use kayak_ui::widgets::{App, NinePatch};
 

--- a/examples/provider.rs
+++ b/examples/provider.rs
@@ -19,7 +19,7 @@ use kayak_ui::{
     core::{
         render, rsx,
         styles::{Edge, LayoutType, Style, StyleProp, Units},
-        widget, Bound, Color, EventType, Index, MutableBound, OnEvent, WidgetProps,
+        widget, Bound, Color, EventType, MutableBound, OnEvent, WidgetProps,
     },
     widgets::{App, Background, Element, If, Text, TooltipConsumer, TooltipProvider, Window},
 };

--- a/examples/scrollbox.rs
+++ b/examples/scrollbox.rs
@@ -7,7 +7,6 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, ImageManager, 
 use kayak_ui::core::{
     render,
     styles::{Edge, Style, StyleProp, Units},
-    Index,
 };
 use kayak_ui::widgets::{App, Inspector, NinePatch, ScrollBox, Text};
 

--- a/examples/shrink_grow_layout.rs
+++ b/examples/shrink_grow_layout.rs
@@ -21,7 +21,7 @@ use kayak_ui::{
     widgets::Button,
 };
 use kayak_ui::{
-    core::{render, rsx, widget, Index},
+    core::{render, rsx, widget},
     widgets::Background,
 };
 

--- a/examples/tabs/tabs.rs
+++ b/examples/tabs/tabs.rs
@@ -15,7 +15,7 @@ use kayak_ui::{
     core::{
         constructor, render, rsx,
         styles::{Style, StyleProp, Units},
-        widget, Color, Index,
+        widget, Color,
     },
     widgets::{App, Text, Window},
 };

--- a/examples/text_box.rs
+++ b/examples/text_box.rs
@@ -9,7 +9,7 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{Style, StyleProp, Units},
-    widget, Index,
+    widget,
 };
 use kayak_ui::widgets::{App, OnChange, TextBox, Window};
 

--- a/examples/todo/todo.rs
+++ b/examples/todo/todo.rs
@@ -7,7 +7,7 @@ use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle
 use kayak_ui::core::{
     render, rsx,
     styles::{LayoutType, Style, StyleProp, Units},
-    use_state, widget, EventType, Handler, Index, OnEvent,
+    use_state, widget, EventType, Handler, OnEvent,
 };
 use kayak_ui::widgets::{App, Element, OnChange, TextBox, Window};
 

--- a/examples/vec_widget.rs
+++ b/examples/vec_widget.rs
@@ -4,7 +4,7 @@ use bevy::{
     DefaultPlugins,
 };
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
-use kayak_ui::core::{constructor, render, Index, VecTracker};
+use kayak_ui::core::{constructor, render, VecTracker};
 use kayak_ui::widgets::{App, Text};
 
 fn startup(

--- a/examples/windows.rs
+++ b/examples/windows.rs
@@ -4,7 +4,6 @@ use bevy::{
     DefaultPlugins,
 };
 use kayak_ui::bevy::{BevyContext, BevyKayakUIPlugin, FontMapping, UICameraBundle};
-use kayak_ui::core::Index;
 use kayak_ui::core::{render, rsx, widget};
 use kayak_ui::widgets::{App, Inspector, Window};
 

--- a/examples/world_interaction.rs
+++ b/examples/world_interaction.rs
@@ -20,7 +20,7 @@ use kayak_ui::{
     core::{
         render, rsx,
         styles::{Edge, Style, StyleProp, Units},
-        use_state, widget, EventType, Index, OnEvent,
+        use_state, widget, EventType, OnEvent,
     },
     widgets::{App, Button, Text, Window},
 };

--- a/kayak_render_macros/src/lib.rs
+++ b/kayak_render_macros/src/lib.rs
@@ -36,7 +36,7 @@ pub fn render(input: TokenStream) -> TokenStream {
 
     let result = quote! {
         let mut context = #kayak_core::KayakContextRef::new(context, None);
-        let parent_id: Option<Index> = None;
+        let parent_id: Option<#kayak_core::Index> = None;
         let children: Option<#kayak_core::Children> = None;
         #widget
         context.commit();


### PR DESCRIPTION
Fixes the dependency on the user needing to use Index.  Instead uses the path to index in the proc macro.  Updates every example to remove the use statement.