### PR TITLE
Enable uuid dependency wasm support

### DIFF
--- a/kayak_core/Cargo.toml
+++ b/kayak_core/Cargo.toml
@@ -18,8 +18,12 @@ kayak_font = { path = "../kayak_font" }
 kayak_render_macros = { path = "../kayak_render_macros" }
 morphorm = { git = "https://github.com/geom3trik/morphorm", rev = "1243152d4cebea46fd3e5098df26402c73acae91" }
 resources = "1.1"
-uuid = { version = "0.8", features = ["v4"] }
 indexmap = "1.8"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+uuid = { version = "0.8", features = ["v4"] }
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "0.8", features = ["v4", "wasm-bindgen"] }
 
 [dependencies.bevy]
 version = "0.8.0"


### PR DESCRIPTION
This PR enables the `wasm-bindgen` feature for the `uuid` dependency used by `kayak_core` when targeting a `wasm32` target. It's a bit unclear how well cargo respects target specific dependencies when _downloading_ crates, but at runtime will have the correct behaviour

Without this feature, the `new_v4()` function will not be defined during a wasm compile, so compilation will fail.

For reference, `uuid` supports both `stdweb` and `wasm-bindgen` features, but this PR only enables the latter