### PR TITLE
Pad shader structs to 16 bytes

### DIFF
--- a/bevy_kayak_renderer/src/render/unified/pipeline.rs
+++ b/bevy_kayak_renderer/src/render/unified/pipeline.rs
@@ -337,6 +337,9 @@ struct QuadVertex {
 #[derive(Copy, Clone, ShaderType)]
 struct QuadType {
     pub t: i32,
+    pub _unused_1: i32,
+    pub _unused_2: i32,
+    pub _unused_3: i32,
 }
 
 pub struct QuadMeta {
@@ -376,9 +379,10 @@ pub fn prepare_quads(
 
     sprite_meta.types_buffer.clear();
     // sprite_meta.types_buffer.reserve(2, &render_device);
-    let quad_type_offset = sprite_meta.types_buffer.push(QuadType { t: 0 });
-    let text_type_offset = sprite_meta.types_buffer.push(QuadType { t: 1 });
-    let image_type_offset = sprite_meta.types_buffer.push(QuadType { t: 2 });
+    let quad_type_offset = sprite_meta.types_buffer.push(QuadType { t: 0, _unused_1: 0, _unused_2: 0, _unused_3: 0, });
+    let text_type_offset = sprite_meta.types_buffer.push(QuadType { t: 1, _unused_1: 0, _unused_2: 0, _unused_3: 0, });
+    let image_type_offset = sprite_meta.types_buffer.push(QuadType { t: 2, _unused_1: 0, _unused_2: 0, _unused_3: 0, });
+
     sprite_meta
         .types_buffer
         .write_buffer(&render_device, &render_queue);

--- a/bevy_kayak_renderer/src/render/unified/pipeline.rs
+++ b/bevy_kayak_renderer/src/render/unified/pipeline.rs
@@ -379,9 +379,24 @@ pub fn prepare_quads(
 
     sprite_meta.types_buffer.clear();
     // sprite_meta.types_buffer.reserve(2, &render_device);
-    let quad_type_offset = sprite_meta.types_buffer.push(QuadType { t: 0, _unused_1: 0, _unused_2: 0, _unused_3: 0, });
-    let text_type_offset = sprite_meta.types_buffer.push(QuadType { t: 1, _unused_1: 0, _unused_2: 0, _unused_3: 0, });
-    let image_type_offset = sprite_meta.types_buffer.push(QuadType { t: 2, _unused_1: 0, _unused_2: 0, _unused_3: 0, });
+    let quad_type_offset = sprite_meta.types_buffer.push(QuadType {
+        t: 0,
+        _unused_1: 0,
+        _unused_2: 0,
+        _unused_3: 0,
+    });
+    let text_type_offset = sprite_meta.types_buffer.push(QuadType {
+        t: 1,
+        _unused_1: 0,
+        _unused_2: 0,
+        _unused_3: 0,
+    });
+    let image_type_offset = sprite_meta.types_buffer.push(QuadType {
+        t: 2,
+        _unused_1: 0,
+        _unused_2: 0,
+        _unused_3: 0,
+    });
 
     sprite_meta
         .types_buffer

--- a/bevy_kayak_renderer/src/render/unified/pipeline.rs
+++ b/bevy_kayak_renderer/src/render/unified/pipeline.rs
@@ -96,7 +96,7 @@ impl FromWorld for UnifiedPipeline {
                     has_dynamic_offset: true,
                     // TODO: change this to ViewUniform::std140_size_static once crevice fixes this!
                     // Context: https://github.com/LPGhatguy/crevice/issues/29
-                    min_binding_size: BufferSize::new(4),
+                    min_binding_size: BufferSize::new(16),
                 },
                 count: None,
             }],

--- a/bevy_kayak_renderer/src/render/unified/pipeline.rs
+++ b/bevy_kayak_renderer/src/render/unified/pipeline.rs
@@ -337,9 +337,9 @@ struct QuadVertex {
 #[derive(Copy, Clone, ShaderType)]
 struct QuadType {
     pub t: i32,
-    pub _unused_1: i32,
-    pub _unused_2: i32,
-    pub _unused_3: i32,
+    pub _padding_1: i32,
+    pub _padding_2: i32,
+    pub _padding_3: i32,
 }
 
 pub struct QuadMeta {
@@ -381,21 +381,21 @@ pub fn prepare_quads(
     // sprite_meta.types_buffer.reserve(2, &render_device);
     let quad_type_offset = sprite_meta.types_buffer.push(QuadType {
         t: 0,
-        _unused_1: 0,
-        _unused_2: 0,
-        _unused_3: 0,
+        _padding_1: 0,
+        _padding_2: 0,
+        _padding_3: 0,
     });
     let text_type_offset = sprite_meta.types_buffer.push(QuadType {
         t: 1,
-        _unused_1: 0,
-        _unused_2: 0,
-        _unused_3: 0,
+        _padding_1: 0,
+        _padding_2: 0,
+        _padding_3: 0,
     });
     let image_type_offset = sprite_meta.types_buffer.push(QuadType {
         t: 2,
-        _unused_1: 0,
-        _unused_2: 0,
-        _unused_3: 0,
+        _padding_1: 0,
+        _padding_2: 0,
+        _padding_3: 0,
     });
 
     sprite_meta

--- a/bevy_kayak_renderer/src/render/unified/shader.wgsl
+++ b/bevy_kayak_renderer/src/render/unified/shader.wgsl
@@ -7,9 +7,9 @@ var<uniform> view: View;
 
 struct QuadType {
     t: i32,
-    _unused_1: i32,
-    _unused_2: i32,
-    _unused_3: i32,
+    _padding_1: i32,
+    _padding_2: i32,
+    _padding_3: i32,
 };
 
 @group(2) @binding(0)
@@ -23,7 +23,6 @@ struct VertexOutput {
     @location(3) size: vec2<f32>,
     @location(4) border_radius: f32,
     @location(5) pixel_position: vec2<f32>,
-    @location(6) _unused: f32,
 };
 
 @vertex
@@ -41,7 +40,6 @@ fn vertex(
     out.uv = vertex_uv.xyz;
     out.size = vertex_pos_size.zw;
     out.border_radius = vertex_uv.w;
-    out._unused = 0.0;
     return out;
 }
 

--- a/bevy_kayak_renderer/src/render/unified/shader.wgsl
+++ b/bevy_kayak_renderer/src/render/unified/shader.wgsl
@@ -7,7 +7,11 @@ var<uniform> view: View;
 
 struct QuadType {
     t: i32,
+    _unused_1: i32,
+    _unused_2: i32,
+    _unused_3: i32,
 };
+
 @group(2) @binding(0)
 var<uniform> quad_type: QuadType;
 
@@ -19,6 +23,7 @@ struct VertexOutput {
     @location(3) size: vec2<f32>,
     @location(4) border_radius: f32,
     @location(5) pixel_position: vec2<f32>,
+    @location(6) _unused: f32,
 };
 
 @vertex
@@ -36,6 +41,7 @@ fn vertex(
     out.uv = vertex_uv.xyz;
     out.size = vertex_pos_size.zw;
     out.border_radius = vertex_uv.w;
+    out._unused = 0.0;
     return out;
 }
 


### PR DESCRIPTION
Fixes #142 

This PR adds unused padding properties to the structs in `shader.wgsl` so that the struct layout is a multiple of 16 bytes, a requirement for WebGL. It also updates the `min_binding_size` to match the new minimum struct size of 16 (otherwise a different error is thrown).

I'm open to the new properties having their names changed to whatever, I figured that `_unused` is descriptive enough.

This change allows the latest version of `kayak_ui` to run successfully on the web (sans fonts, for now)