### PR TITLE
Update hello_world to follow new bevy behavior for settings

### DIFF
--- a/book/src/chapter_1.md
+++ b/book/src/chapter_1.md
@@ -44,8 +44,7 @@ fn startup(
 
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest())
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_plugin(KayakContextPlugin)
         .add_plugin(KayakWidgets)
         .add_startup_system(startup)
@@ -114,8 +113,7 @@ fn startup(
 }
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest())
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_plugin(KayakContextPlugin)
         .add_plugin(KayakWidgets)
         .add_startup_system(startup)


### PR DESCRIPTION
Currently the hello world project fails to compile with an ImageSettings undeclared error. Bevy no longer uses resources for startup settings. This change brings the hello world example into compliance, and allows copy-paste of tutorial code to not fail to compile.

see: https://github.com/bevyengine/bevy/commit/5622d56be1262fce8a2d458f2b78abf1cab3ab50