### PR TITLE
Update: startup resources are now plugin settings

### DIFF
--- a/book/src/chapter_1.md
+++ b/book/src/chapter_1.md
@@ -44,8 +44,7 @@ fn startup(
 
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest())
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_plugin(KayakContextPlugin)
         .add_plugin(KayakWidgets)
         .add_startup_system(startup)
@@ -114,8 +113,7 @@ fn startup(
 }
 fn main() {
     App::new()
-        .insert_resource(ImageSettings::default_nearest())
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_plugin(KayakContextPlugin)
         .add_plugin(KayakWidgets)
         .add_startup_system(startup)


### PR DESCRIPTION
ImageSettings was removed from Bevy, startup settings are now plugin settings not resources. These changes allow the example code to compile with the recommended(required) versions of Bevy.

See: https://github.com/bevyengine/bevy/commit/5622d56be1262fce8a2d458f2b78abf1cab3ab50