### PR TITLE
Fix app not updating if camera width/height changes

### DIFF
--- a/examples/test_no_startup.rs
+++ b/examples/test_no_startup.rs
@@ -1,0 +1,49 @@
+use bevy::prelude::*;
+use kayak_ui::prelude::{widgets::*, *};
+
+#[derive(Default, Clone, Copy, PartialEq, Hash, Eq, Debug)]
+pub enum GameState {
+    #[default]
+    First,
+    Second,
+}
+
+fn first_sys(mut state: ResMut<State<GameState>>) {
+    state.overwrite_replace(GameState::Second).unwrap();
+}
+
+fn second_sys(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut font_mapping: ResMut<FontMapping>,
+) {
+    font_mapping.set_default(asset_server.load("roboto.kayak_font"));
+
+    let mut widget_context = KayakRootContext::new();
+    widget_context.add_plugin(KayakWidgetsContextPlugin);
+    let parent_id = None;
+    rsx! {
+        <KayakAppBundle>
+            <TextWidgetBundle
+                text={TextProps {
+                    content: "Hello World".into(),
+                    size: 20.0,
+                    ..Default::default()
+                }}
+            />
+        </KayakAppBundle>
+    }
+
+    commands.spawn(UICameraBundle::new(widget_context));
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(KayakContextPlugin)
+        .add_plugin(KayakWidgets)
+        .add_state(GameState::First)
+        .add_system_set(SystemSet::on_enter(GameState::First).with_system(first_sys))
+        .add_system_set(SystemSet::on_enter(GameState::Second).with_system(second_sys))
+        .run()
+}

--- a/src/widgets/app.rs
+++ b/src/widgets/app.rs
@@ -41,18 +41,22 @@ impl Default for KayakAppBundle {
 
 pub fn app_update(
     In((widget_context, entity, previous_props_entity)): In<(KayakWidgetContext, Entity, Entity)>,
-    windows: Res<Windows>,
     widget_param: WidgetParam<KayakApp, EmptyState>,
+    camera: Query<&Camera, With<CameraUIKayak>>,
 ) -> bool {
-    let primary_window = windows.get_primary().unwrap();
-
     let mut window_change = false;
     if let Ok(app_style) = widget_param.style_query.get(entity) {
-        if app_style.width != StyleProp::Value(Units::Pixels(primary_window.width())) {
-            window_change = true;
-        }
-        if app_style.height != StyleProp::Value(Units::Pixels(primary_window.height())) {
-            window_change = true;
+        if let Some(camera_entity) = widget_context.camera_entity {
+            if let Ok(camera) = camera.get(camera_entity) {
+                if let Some(size) = camera.logical_viewport_size() {
+                    if app_style.width != StyleProp::Value(Units::Pixels(size.x)) {
+                        window_change = true;
+                    }
+                    if app_style.height != StyleProp::Value(Units::Pixels(size.y)) {
+                        window_change = true;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
If you do not use a startup system to instantiate `UICameraBundle` and instead insert the bundle at a later time within the app lifetime, the width/height are set to 0 and not updated. This should check if the camera has changed and apply the correct fix

edit: should address #165 