### PR TITLE
Update link to font chapter

### DIFF
--- a/book/src/chapter_1.md
+++ b/book/src/chapter_1.md
@@ -5,7 +5,7 @@ Kayak UI is quite easy to setup! First make sure you add it to your cargo.toml f
 kayak_ui = "0.1"
 ```
 
-Once you've added Kayak UI to your bevy project you can now start to use it! In order for you to copy and run this in your own project don't forget to move the `roboto.kayak_font` and the `roboto.png` files to your asset folder. Optionally you can also generate your own font! See: [Chapter 5 - Fonts](./chapter_5.md)
+Once you've added Kayak UI to your bevy project you can now start to use it! In order for you to copy and run this in your own project don't forget to move the `roboto.kayak_font` and the `roboto.png` files to your asset folder. Optionally you can also generate your own font! See: [Chapter 5 - Fonts](./chapter_6.md)
 
 Hello World Example:
 ```rust


### PR DESCRIPTION
It was a link to `chapter_5.md`, which is chapter 4. I changed it to `chapter_6.md`.

This corrects the first page of the book, with the correct link to the Chapter 5: Fonts chapter.