### PR TITLE
make rsx macro return the root entity

### DIFF
--- a/examples/bevy_scene.rs
+++ b/examples/bevy_scene.rs
@@ -253,7 +253,7 @@ fn startup(
                 />
             </WindowBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn((UICameraBundle::new(widget_context), GameUI));
 }

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -54,7 +54,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sed tellus neque. 
                 </ClipBundle>
             </NinePatchBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/conditional_widget.rs
+++ b/examples/conditional_widget.rs
@@ -98,7 +98,7 @@ fn my_widget_render(
                     }
                 }}
             </ElementBundle>
-        }
+        };
     }
 
     true
@@ -128,7 +128,7 @@ fn startup(
         <KayakAppBundle>
             <MyWidgetBundle />
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -124,7 +124,7 @@ fn update_theme_button(
                             },
                         )}
                     />
-                }
+                };
             }
         }
     }
@@ -182,7 +182,7 @@ fn update_theme_selector(
                 <ThemeButtonBundle theme_button={ThemeButton { theme: solar_theme }} />
                 <ThemeButtonBundle theme_button={ThemeButton { theme: vector_theme }} />
             </ElementBundle>
-        }
+        };
     }
 
     true
@@ -312,7 +312,7 @@ fn update_theme_demo(
                             }
                         </BackgroundBundle>
                     </ElementBundle>
-                }
+                };
             }
         }
     }
@@ -375,7 +375,7 @@ fn startup(
                 />
             </WindowBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -21,7 +21,7 @@ fn startup(
                 }}
             />
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -28,7 +28,7 @@ fn startup(
                 }}
             />
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/main_menu.rs
+++ b/examples/main_menu.rs
@@ -107,7 +107,7 @@ fn menu_button_render(
                     }}
                 />
             </NinePatchBundle>
-        }
+        };
     }
     true
 }
@@ -216,7 +216,7 @@ fn startup(
                 />
             </NinePatchBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/nine_patch.rs
+++ b/examples/nine_patch.rs
@@ -49,7 +49,7 @@ fn startup(
                 }}
             />
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/quads.rs
+++ b/examples/quads.rs
@@ -132,7 +132,7 @@ fn startup(
                 });
             }
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/render_target.rs
+++ b/examples/render_target.rs
@@ -80,7 +80,7 @@ fn startup(
                 }}
             />
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle {
         camera: Camera {
@@ -147,7 +147,7 @@ fn startup(
                 }}
             />
         </KayakAppBundle>
-    }
+    };
     commands.spawn((UICameraBundle::new(widget_context), MainUI));
 }
 

--- a/examples/scrolling.rs
+++ b/examples/scrolling.rs
@@ -58,7 +58,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras sed tellus neque. 
                 </ScrollContextProviderBundle>
             </WindowBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/simple_state.rs
+++ b/examples/simple_state.rs
@@ -74,7 +74,7 @@ fn current_count_render(
                     )}
                 />
             </ElementBundle>
-        }
+        };
     }
 
     true
@@ -127,7 +127,7 @@ fn startup(
                 </WindowBundle>
             </WindowContextProviderBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/tabs/tab.rs
+++ b/examples/tabs/tab.rs
@@ -52,7 +52,7 @@ pub fn tab_render(
             if tab_context.current_index == tab.index {
                 rsx! {
                     <BackgroundBundle styles={styles} children={children.clone()} />
-                }
+                };
             }
         }
     }

--- a/examples/tabs/tab_button.rs
+++ b/examples/tabs/tab_button.rs
@@ -86,7 +86,7 @@ pub fn tab_button_render(
                     }}
                     on_event={on_event}
                 />
-            }
+            };
         }
     }
     true

--- a/examples/tabs/tabs.rs
+++ b/examples/tabs/tabs.rs
@@ -85,7 +85,7 @@ fn startup(
                 </TabContextProviderBundle>
             </WindowBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/test_no_startup.rs
+++ b/examples/test_no_startup.rs
@@ -32,7 +32,7 @@ fn second_sys(
                 }}
             />
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -90,7 +90,7 @@ fn startup(
     );
     rsx! {
         <KayakAppBundle><MyWidgetBundle props={MyWidgetProps { foo: 0 }} /></KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/text_box.rs
+++ b/examples/text_box.rs
@@ -78,7 +78,7 @@ fn update_text_box_example(
                     on_change={on_change2}
                 />
             </ElementBundle>
-        }
+        };
     }
     true
 }
@@ -118,7 +118,7 @@ fn startup(
                 <TextBoxExampleBundle />
             </WindowBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/texture_atlas.rs
+++ b/examples/texture_atlas.rs
@@ -66,7 +66,7 @@ fn startup(
                 styles={atlas_styles}
             />
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/todo/input.rs
+++ b/examples/todo/input.rs
@@ -111,6 +111,6 @@ pub fn render_todo_input(
                 on_event={handle_click}
             />
         </ElementBundle>
-    }
+    };
     true
 }

--- a/examples/todo/items.rs
+++ b/examples/todo/items.rs
@@ -104,6 +104,6 @@ pub fn render_todo_items(
                 }
             })}
         </ElementBundle>
-    }
+    };
     true
 }

--- a/examples/todo/todo.rs
+++ b/examples/todo/todo.rs
@@ -97,7 +97,7 @@ fn startup(
                 </ScrollContextProviderBundle>
             </WindowBundle>
         </KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/examples/vec.rs
+++ b/examples/vec.rs
@@ -28,7 +28,7 @@ fn my_widget_1_update(
                     }
                 })}
             </ElementBundle>
-        }
+        };
         return true;
     }
 
@@ -70,7 +70,7 @@ fn startup(
     );
     rsx! {
         <KayakAppBundle><MyWidgetBundle /></KayakAppBundle>
-    }
+    };
 
     commands.spawn(UICameraBundle::new(widget_context));
 }

--- a/kayak_ui_macros/src/widget.rs
+++ b/kayak_ui_macros/src/widget.rs
@@ -71,11 +71,12 @@ impl Widget {
                     let widget_block =
                         build_widget_stream(quote! { built_widget }, constructor, 0, false);
                     (
-                        entity_id,
+                        entity_id.clone(),
                         quote! {{
                             let parent_org = parent_id;
                             #props
                             #widget_block
+                            #entity_id
                         }},
                     )
                 } else {

--- a/src/widgets/app.rs
+++ b/src/widgets/app.rs
@@ -125,7 +125,7 @@ pub fn app_render(
             <ClipBundle
                 children={children.clone()}
             />
-        }
+        };
     }
 
     true

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -138,7 +138,7 @@ pub fn button_render(
                         }}
                     />
                 </ElementBundle>
-            }
+            };
         }
     }
 

--- a/src/widgets/scroll/scroll_bar.rs
+++ b/src/widgets/scroll/scroll_bar.rs
@@ -307,7 +307,7 @@ pub fn scroll_bar_render(
                             <BackgroundBundle styles={thumb_style} />
                         </ClipBundle>
                     </BackgroundBundle>
-                }
+                };
             }
         }
     }

--- a/src/widgets/scroll/scroll_box.rs
+++ b/src/widgets/scroll/scroll_box.rs
@@ -263,7 +263,7 @@ pub fn scroll_box_render(
                             }
                         }}
                     </ElementBundle>
-                }
+                };
             }
         }
     }

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -371,7 +371,7 @@ pub fn text_box_render(
                         </ElementBundle>
                     </ClipBundle>
                 </BackgroundBundle>
-            }
+            };
         }
     }
 

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -281,7 +281,7 @@ pub fn window_render(
                         children={window_children.clone()}
                     />
                 </ElementBundle>
-            }
+            };
         }
     }
 


### PR DESCRIPTION
The idea is to be able to do something like 
```rust
let my_text_entity = rsx! {
    <TextWidgetBundle
        // ...
    />
};
``` 
it does impact all the examples as we now have to put a semicolon after each rsx! call if they are invoked with curly brackets. 

It might be better to have a macro token returning the entity only when needed? 