### PR TITLE
Add missing license fields to cargo manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/kayak_ui"
 repository = "https://github.com/StarArawn/kayak_ui"
+license = "MIT OR Apache-2.0"
 license-file = "LICENSE"
 exclude = ["assets/*", "screenshots/*", "book"]
 

--- a/kayak_font/Cargo.toml
+++ b/kayak_font/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/kayak_ui"
 repository = "https://github.com/StarArawn/kayak_ui"
+license = "MIT OR Apache-2.0"
 license-file = "../LICENSE"
 exclude = ["assets/*"]
 

--- a/kayak_ui_macros/Cargo.toml
+++ b/kayak_ui_macros/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/kayak_ui"
 repository = "https://github.com/StarArawn/kayak_ui"
+license = "MIT OR Apache-2.0"
 license-file = "../LICENSE"
 
 [lib]


### PR DESCRIPTION
The license file already says MIT or Apache-2.0, but this make the crates behave well with tools like cargo-deny as well :)