### PR TITLE
Don't depend on bevy default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = ["kayak_ui_macros", "kayak_font"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.9" }
+bevy = { version = "0.9", default-features = false, features = ["bevy_ui"] }
 bytemuck = "1.12"
 dashmap = "5.4"
 kayak_font = { path = "./kayak_font", version = "0.2" }


### PR DESCRIPTION
This made it incompatible with bevy_kira_audio for instance.