### PR TITLE
Add `instant` dependency for time in wasm build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4"
 bitflags = "1.3.2"
 reorder = "2.1"
 resources = "1.1"
+instant = "0.1"
 
 [dev-dependencies]
 fastrand = "1.8"

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use instant::Instant;
 
 use bevy::prelude::*;
 use kayak_font::{KayakFont, TextProperties};


### PR DESCRIPTION
`instant` uses `std::time` in supported platforms and `web-sys` for wasm, so no need for `cfg` flags