### PR TITLE
Update to bevy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ resolver = "2"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/kayak_ui"
 repository = "https://github.com/StarArawn/kayak_ui"
-license = "MIT OR Apache-2.0"
 license-file = "LICENSE"
 exclude = ["assets/*", "screenshots/*", "book"]
 
@@ -17,7 +16,7 @@ members = ["kayak_ui_macros", "kayak_font"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.9", default-features = false, features = ["bevy_ui"] }
+bevy = { version = "0.10", default-features = false, features = ["bevy_render", "bevy_asset", "bevy_winit", "bevy_core_pipeline"] }
 bytemuck = "1.12"
 dashmap = "5.4"
 kayak_font = { path = "./kayak_font", version = "0.2" }
@@ -32,7 +31,8 @@ instant = "0.1"
 
 [dev-dependencies]
 fastrand = "1.8"
-bevy-inspector-egui = "0.14"
+bevy-inspector-egui = "0.18"
+bevy = { version = "0.10", default-features = true }
 
 [[example]]
 name = "tabs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = ["kayak_ui_macros", "kayak_font"]
 
 [dependencies]
 bevy = { version = "0.10", default-features = false, features = ["bevy_render", "bevy_asset", "bevy_winit", "bevy_core_pipeline"] }
-bytemuck = "1.12"
+bytemuck = { version = "1.12", features = ["derive"] }
 dashmap = "5.4"
 kayak_font = { path = "./kayak_font", version = "0.2" }
 morphorm = "0.3"

--- a/examples/conditional_widget.rs
+++ b/examples/conditional_widget.rs
@@ -48,7 +48,7 @@ fn my_widget_render(
                         text: "Show Window".into(),
                     }}
                     on_event={OnEvent::new(
-                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, Event, Entity)>,
+                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
                             mut query: Query<&mut MyWidgetState>| {
                             event.prevent_default();
                             event.stop_propagation();
@@ -78,7 +78,7 @@ fn my_widget_render(
                             <KButtonBundle
                                 button={KButton { text: "Hide Window".into(), ..Default::default() }}
                                 on_event={OnEvent::new(
-                                    move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, Event, Entity)>,
+                                    move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
                                         mut query: Query<&mut MyWidgetState>| {
                                         match event.event_type {
                                             EventType::Click(..) => {

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -104,7 +104,7 @@ fn update_theme_button(
                             move |In((event_dispatcher_context, _, event, _entity)): In<(
                                 EventDispatcherContext,
                                 WidgetState,
-                                Event,
+                                KEvent,
                                 Entity,
                             )>,
                             query: Query<&ThemeButton>,

--- a/examples/main_menu.rs
+++ b/examples/main_menu.rs
@@ -49,7 +49,7 @@ fn menu_button_render(
         move |In((event_dispatcher_context, _, mut event, _entity)): In<(
             EventDispatcherContext,
             WidgetState,
-            Event,
+            KEvent,
             Entity,
         )>,
               mut query: Query<&mut ButtonState>| {
@@ -151,7 +151,7 @@ fn startup(
         move |In((event_dispatcher_context, _, event, _entity)): In<(
             EventDispatcherContext,
             WidgetState,
-            Event,
+            KEvent,
             Entity,
         )>,
               mut exit: EventWriter<AppExit>| {

--- a/examples/quads.rs
+++ b/examples/quads.rs
@@ -39,7 +39,7 @@ fn my_quad_update(
             move |In((event_dispatcher_context, _, mut event, entity)): In<(
                 EventDispatcherContext,
                 WidgetState,
-                Event,
+                KEvent,
                 Entity,
             )>,
                   mut query: Query<(&mut KStyle, &MyQuad)>| {

--- a/examples/render_target.rs
+++ b/examples/render_target.rs
@@ -41,6 +41,7 @@ fn startup(
             label: None,
             size,
             dimension: TextureDimension::D2,
+            view_formats: &[TextureFormat::Bgra8UnormSrgb],
             format: TextureFormat::Bgra8UnormSrgb,
             mip_level_count: 1,
             sample_count: 1,
@@ -84,7 +85,7 @@ fn startup(
 
     commands.spawn(UICameraBundle {
         camera: Camera {
-            priority: -1,
+            order: -1,
             target: RenderTarget::Image(image_handle.clone()),
             ..Camera::default()
         },

--- a/examples/simple_state.rs
+++ b/examples/simple_state.rs
@@ -57,7 +57,7 @@ fn current_count_render(
                         ..Default::default()
                     }}
                     on_event={OnEvent::new(
-                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, Event, Entity)>,
+                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
                             mut query: Query<&mut CurrentCountState>| {
                             match event.event_type {
                                 EventType::Click(..) => {

--- a/examples/tabs/tab_button.rs
+++ b/examples/tabs/tab_button.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query};
 use kayak_ui::{
     prelude::{
-        rsx, widgets::KButtonBundle, Corner, Event, EventDispatcherContext, EventType, KStyle,
+        rsx, widgets::KButtonBundle, Corner, EventDispatcherContext, EventType, KEvent, KStyle,
         KayakWidgetContext, OnEvent, StyleProp, Units, Widget, WidgetName, WidgetState,
     },
     widgets::KButton,
@@ -57,7 +57,7 @@ pub fn tab_button_render(
                 move |In((event_dispatcher_context, _, event, _entity)): In<(
                     EventDispatcherContext,
                     WidgetState,
-                    Event,
+                    KEvent,
                     Entity,
                 )>,
                       mut query: Query<&mut TabContext>| {

--- a/examples/test_no_startup.rs
+++ b/examples/test_no_startup.rs
@@ -1,15 +1,15 @@
 use bevy::prelude::*;
 use kayak_ui::prelude::{widgets::*, *};
 
-#[derive(Default, Clone, Copy, PartialEq, Hash, Eq, Debug)]
+#[derive(Default, Clone, Copy, PartialEq, Hash, Eq, Debug, States)]
 pub enum GameState {
     #[default]
     First,
     Second,
 }
 
-fn first_sys(mut state: ResMut<State<GameState>>) {
-    state.overwrite_replace(GameState::Second).unwrap();
+fn first_sys(mut state: ResMut<NextState<GameState>>) {
+    state.set(GameState::Second);
 }
 
 fn second_sys(
@@ -42,8 +42,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(KayakContextPlugin)
         .add_plugin(KayakWidgets)
-        .add_state(GameState::First)
-        .add_system_set(SystemSet::on_enter(GameState::First).with_system(first_sys))
-        .add_system_set(SystemSet::on_enter(GameState::Second).with_system(second_sys))
-        .run()
+        .add_state::<GameState>()
+        .add_system(first_sys.in_schedule(OnEnter(GameState::First)))
+        .add_system(second_sys.in_schedule(OnEnter(GameState::Second)))
+        .run();
 }

--- a/examples/todo/input.rs
+++ b/examples/todo/input.rs
@@ -52,7 +52,7 @@ pub fn render_todo_input(
         move |In((event_dispatcher_context, _, event, _)): In<(
             EventDispatcherContext,
             WidgetState,
-            Event,
+            KEvent,
             Entity,
         )>,
               mut todo_list: ResMut<TodoList>| {

--- a/examples/todo/items.rs
+++ b/examples/todo/items.rs
@@ -50,7 +50,7 @@ pub fn render_todo_items(
                     move |In((event_dispatcher_context, _, event, _)): In<(
                         EventDispatcherContext,
                         WidgetState,
-                        Event,
+                        KEvent,
                         Entity,
                     )>,
                         mut todo_list: ResMut<TodoList>,| {

--- a/examples/todo/todo.rs
+++ b/examples/todo/todo.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use kayak_ui::prelude::{widgets::*, *};
 
 mod input;
@@ -106,10 +106,10 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.0, 0.0, 0.0)))
         .add_plugins(DefaultPlugins)
-        .add_plugin(WorldInspectorPlugin::new())
+        .add_plugin(WorldInspectorPlugin::default())
         .add_plugin(KayakContextPlugin)
         .add_plugin(KayakWidgets)
-        .insert_non_send_resource(TodoList::new())
+        .insert_resource(TodoList::new())
         .add_startup_system(startup)
         .run()
 }

--- a/kayak_font/Cargo.toml
+++ b/kayak_font/Cargo.toml
@@ -7,7 +7,6 @@ resolver = "2"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/kayak_ui"
 repository = "https://github.com/StarArawn/kayak_ui"
-license = "MIT OR Apache-2.0"
 license-file = "../LICENSE"
 exclude = ["assets/*"]
 
@@ -28,8 +27,8 @@ image = "0.24"
 # Provides UAX #14 line break segmentation
 xi-unicode = "0.3"
 
-bevy = { version = "0.9", optional = true, default-features = false, features = ["bevy_asset", "bevy_render", "bevy_core_pipeline"] }
+bevy = { version = "0.10", optional = true, default-features = false, features = ["bevy_asset", "bevy_render", "bevy_core_pipeline"] }
 
 [dev-dependencies]
-bevy = { version = "0.9" }
+bevy = { version = "0.10" }
 bytemuck = "1.12.0"

--- a/kayak_font/src/bevy/mod.rs
+++ b/kayak_font/src/bevy/mod.rs
@@ -11,8 +11,8 @@ mod loader;
 mod renderer;
 
 mod plugin {
-    use bevy::prelude::{AddAsset, Plugin};
-    use bevy::render::{RenderApp, RenderStage};
+    use bevy::prelude::{AddAsset, IntoSystemAppConfig, IntoSystemConfig, Plugin};
+    use bevy::render::{ExtractSchedule, RenderApp, RenderSet};
 
     use crate::bevy::font_texture::init_font_texture;
     use crate::KayakFont;
@@ -32,8 +32,8 @@ mod plugin {
             render_app
                 .init_resource::<FontTextureCache>()
                 .init_resource::<ExtractedFonts>()
-                .add_system_to_stage(RenderStage::Extract, extract_fonts)
-                .add_system_to_stage(RenderStage::Prepare, prepare_fonts);
+                .add_system(extract_fonts.in_schedule(ExtractSchedule))
+                .add_system(prepare_fonts.in_set(RenderSet::Prepare));
         }
     }
 }

--- a/kayak_font/src/bevy/renderer/font_texture_cache.rs
+++ b/kayak_font/src/bevy/renderer/font_texture_cache.rs
@@ -126,6 +126,7 @@ impl FontTextureCache {
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
+            view_formats: &[format],
             format,
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
         };
@@ -163,6 +164,7 @@ impl FontTextureCache {
             texture,
             sampler,
             texture_view,
+            mip_level_count: 1,
             size: Vec2 {
                 x: size.0 as f32,
                 y: size.1 as f32,
@@ -184,6 +186,7 @@ impl FontTextureCache {
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
+            view_formats: &[TextureFormat::Rgba8Unorm],
             format: TextureFormat::Rgba8Unorm,
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
         };
@@ -208,6 +211,7 @@ impl FontTextureCache {
             texture,
             sampler,
             texture_view,
+            mip_level_count: 1,
             size: Vec2 { x: 1.0, y: 1.0 },
             texture_format: TextureFormat::Rgba8Unorm,
         };

--- a/kayak_ui_macros/Cargo.toml
+++ b/kayak_ui_macros/Cargo.toml
@@ -7,7 +7,6 @@ resolver = "2"
 authors = ["John Mitchell"]
 homepage = "https://github.com/StarArawn/kayak_ui"
 repository = "https://github.com/StarArawn/kayak_ui"
-license = "MIT OR Apache-2.0"
 license-file = "../LICENSE"
 
 [lib]

--- a/src/camera/camera.rs
+++ b/src/camera/camera.rs
@@ -1,9 +1,8 @@
 use bevy::{
     core_pipeline::clear_color::ClearColorConfig,
-    ecs::query::QueryItem,
-    prelude::{Bundle, Component, GlobalTransform, Transform, With},
+    prelude::{Bundle, Component, GlobalTransform, Transform, Vec2},
     render::{
-        camera::{Camera, CameraProjection, CameraRenderGraph, WindowOrigin},
+        camera::{Camera, CameraProjection, CameraRenderGraph},
         extract_component::ExtractComponent,
         primitives::Frustum,
         view::VisibleEntities,
@@ -15,18 +14,9 @@ use crate::{context::KayakRootContext, event_dispatcher::EventDispatcher};
 use super::ortho::UIOrthographicProjection;
 
 /// Kayak UI's default UI camera.
-#[derive(Component, Clone, Default)]
+#[derive(Component, ExtractComponent, Clone, Default)]
 pub struct CameraUIKayak {
     pub clear_color: ClearColorConfig,
-}
-
-impl ExtractComponent for CameraUIKayak {
-    type Query = &'static Self;
-    type Filter = With<Camera>;
-
-    fn extract_component(item: QueryItem<Self::Query>) -> Self {
-        item.clone()
-    }
 }
 
 /// Kayak UI's default UI camera bundle.
@@ -60,7 +50,7 @@ impl UICameraBundle {
 
         let orthographic_projection = UIOrthographicProjection {
             far,
-            window_origin: WindowOrigin::BottomLeft,
+            window_origin: Vec2::new(0.0, 0.0),
             ..Default::default()
         };
 
@@ -68,15 +58,10 @@ impl UICameraBundle {
 
         let view_projection =
             orthographic_projection.get_projection_matrix() * transform.compute_matrix().inverse();
-        let frustum = Frustum::from_view_projection(
-            &view_projection,
-            &transform.translation,
-            &transform.back(),
-            orthographic_projection.far(),
-        );
+        let frustum = Frustum::from_view_projection(&view_projection);
         UICameraBundle {
             camera: Camera {
-                priority: isize::MAX - 1,
+                order: isize::MAX - 1,
                 ..Default::default()
             },
             camera_render_graph: CameraRenderGraph::new(bevy::core_pipeline::core_2d::graph::NAME),

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{CoreStage, Plugin},
+    prelude::{CoreSet, IntoSystemConfig, Plugin},
     render::{camera::CameraProjectionPlugin, extract_component::ExtractComponentPlugin},
 };
 
@@ -13,9 +13,9 @@ pub struct KayakUICameraPlugin;
 
 impl Plugin for KayakUICameraPlugin {
     fn build(&self, app: &mut bevy::prelude::App) {
-        app.add_system_to_stage(
-            CoreStage::PostUpdate,
-            bevy::render::camera::camera_system::<UIOrthographicProjection>,
+        app.add_system(
+            bevy::render::camera::camera_system::<UIOrthographicProjection>
+                .in_base_set(CoreSet::PostUpdate),
         )
         .add_plugin(CameraProjectionPlugin::<UIOrthographicProjection>::default())
         .add_plugin(ExtractComponentPlugin::<CameraUIKayak>::default());

--- a/src/camera/ortho.rs
+++ b/src/camera/ortho.rs
@@ -1,9 +1,9 @@
 use bevy::ecs::reflect::ReflectComponent;
-use bevy::prelude::Component;
+use bevy::prelude::{Component, Vec2};
 use bevy::{
     math::Mat4,
     reflect::Reflect,
-    render::camera::{CameraProjection, ScalingMode, WindowOrigin},
+    render::camera::{CameraProjection, ScalingMode},
 };
 
 /// Kayak UI's default orthographic projection matrix
@@ -19,7 +19,7 @@ pub struct UIOrthographicProjection {
     pub top: f32,
     pub near: f32,
     pub far: f32,
-    pub window_origin: WindowOrigin,
+    pub window_origin: Vec2,
     pub scaling_mode: ScalingMode,
     pub scale: f32,
 }
@@ -39,8 +39,11 @@ impl CameraProjection for UIOrthographicProjection {
     }
 
     fn update(&mut self, width: f32, height: f32) {
-        match (&self.scaling_mode, &self.window_origin) {
-            (ScalingMode::WindowSize, WindowOrigin::BottomLeft) => {
+        match &self.scaling_mode {
+            ScalingMode::WindowSize(scale) => {
+                if *scale != 1.0 || self.window_origin != Vec2::ZERO {
+                    return;
+                }
                 self.left = 0.0;
                 self.right = width;
                 self.top = 0.0;
@@ -64,8 +67,8 @@ impl Default for UIOrthographicProjection {
             top: 1.0,
             near: 0.0,
             far: 1000.0,
-            window_origin: WindowOrigin::Center,
-            scaling_mode: ScalingMode::WindowSize,
+            window_origin: Vec2::new(0.5, 0.5),
+            scaling_mode: ScalingMode::WindowSize(1.0),
             scale: 1.0,
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// An event type sent to widgets
 #[derive(Clone)]
-pub struct Event {
+pub struct KEvent {
     /// The node targeted by this event
     pub target: Entity,
     /// The current target of this event
@@ -23,7 +23,7 @@ pub struct Event {
     pub(crate) on_change_systems: Vec<OnChange>,
 }
 
-impl PartialEq for Event {
+impl PartialEq for KEvent {
     fn eq(&self, other: &Self) -> bool {
         self.target == other.target
             && self.current_target == other.current_target
@@ -33,7 +33,7 @@ impl PartialEq for Event {
     }
 }
 
-impl Default for Event {
+impl Default for KEvent {
     fn default() -> Self {
         Self {
             target: Entity::from_raw(0),
@@ -46,7 +46,7 @@ impl Default for Event {
     }
 }
 
-impl Event {
+impl KEvent {
     /// Create a new event
     ///
     /// This is the preferred method for creating an event as it automatically sets up

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,6 +5,7 @@ use bevy::{
         ButtonState,
     },
     prelude::*,
+    window::PrimaryWindow,
 };
 
 use crate::{
@@ -14,13 +15,11 @@ use crate::{
 };
 
 pub(crate) fn process_events(world: &mut World) {
-    let window_size = if let Some(windows) = world.get_resource::<Windows>() {
-        if let Some(window) = windows.get_primary() {
-            Vec2::new(window.width(), window.height())
-        } else {
-            log::warn!("Couldn't find primiary window!");
-            return;
-        }
+    let window_size = if let Ok(window) = world
+        .query_filtered::<&Window, With<PrimaryWindow>>()
+        .get_single(&world)
+    {
+        Vec2::new(window.width(), window.height())
     } else {
         log::warn!("Couldn't find primiary window!");
         return;
@@ -133,7 +132,7 @@ pub(crate) fn query_world<T: bevy::ecs::system::SystemParam + 'static, F, R>(
     world: &mut World,
 ) -> R
 where
-    F: FnOnce(<T::Fetch as bevy::ecs::system::SystemParamFetch<'_, '_>>::Item) -> R,
+    F: FnOnce(<T as bevy::ecs::system::SystemParam>::Item<'_, '_>) -> R,
 {
     let mut system_state = bevy::ecs::system::SystemState::<T>::new(world);
     let r = {

--- a/src/layout_dispatcher.rs
+++ b/src/layout_dispatcher.rs
@@ -67,7 +67,7 @@ impl LayoutEventDispatcher {
         // We should be able to just get layout from WidgetManager here
         // since the layouts will be calculated by this point
         if let Some(mut entity) = world.get_entity_mut(index.0) {
-            if let Some(mut on_layout) = entity.remove::<OnLayout>() {
+            if let Some(mut on_layout) = entity.take::<OnLayout>() {
                 if let Some(rect) = layout_cache.rect.get(&index) {
                     // dbg!(format!("Processing event for: {:?}", entity.id()));
                     let layout_event = LayoutEvent::new(*rect, flags, index.0);

--- a/src/on_event.rs
+++ b/src/on_event.rs
@@ -2,7 +2,7 @@ use bevy::prelude::{Component, Entity, In, IntoSystem, System, World};
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLock};
 
-use crate::event::Event;
+use crate::event::KEvent;
 use crate::event_dispatcher::EventDispatcherContext;
 use crate::widget_state::WidgetState;
 
@@ -17,8 +17,8 @@ pub struct OnEvent {
     system: Arc<
         RwLock<
             dyn System<
-                In = (EventDispatcherContext, WidgetState, Event, Entity),
-                Out = (EventDispatcherContext, Event),
+                In = (EventDispatcherContext, WidgetState, KEvent, Entity),
+                Out = (EventDispatcherContext, KEvent),
             >,
         >,
     >,
@@ -42,8 +42,8 @@ impl OnEvent {
     /// 2. The event
     pub fn new<Params>(
         system: impl IntoSystem<
-            (EventDispatcherContext, WidgetState, Event, Entity),
-            (EventDispatcherContext, Event),
+            (EventDispatcherContext, WidgetState, KEvent, Entity),
+            (EventDispatcherContext, KEvent),
             Params,
         >,
     ) -> OnEvent {
@@ -61,9 +61,9 @@ impl OnEvent {
         mut event_dispatcher_context: EventDispatcherContext,
         widget_state: WidgetState,
         entity: Entity,
-        mut event: Event,
+        mut event: KEvent,
         world: &mut World,
-    ) -> (EventDispatcherContext, Event) {
+    ) -> (EventDispatcherContext, KEvent) {
         if let Ok(mut system) = self.system.try_write() {
             if !self.has_initialized {
                 system.initialize(world);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,9 +1,9 @@
 use bevy::{
-    prelude::{App, Camera, Commands, Entity, Plugin, Query, With},
+    prelude::{App, Camera, Commands, Entity, IntoSystemAppConfig, Plugin, Query, With},
     render::{
         render_graph::{RenderGraph, RunGraphOnViewNode, SlotInfo, SlotType},
         render_phase::{DrawFunctions, RenderPhase},
-        Extract, RenderApp, RenderStage,
+        Extract, ExtractSchedule, RenderApp,
     },
 };
 
@@ -43,7 +43,7 @@ impl Plugin for BevyKayakUIRenderPlugin {
         let render_app = app.sub_app_mut(RenderApp);
         render_app
             .init_resource::<DrawFunctions<TransparentUI>>()
-            .add_system_to_stage(RenderStage::Extract, extract_core_pipeline_camera_phases);
+            .add_system(extract_core_pipeline_camera_phases.in_schedule(ExtractSchedule));
         // .add_system_to_stage(RenderStage::PhaseSort, sort_phase_system::<TransparentUI>);
 
         // let pass_node_ui = MainPassUINode::new(&mut render_app.world);
@@ -78,32 +78,24 @@ impl Plugin for BevyKayakUIRenderPlugin {
                 draw_ui_graph::node::MAIN_PASS,
                 RunGraphOnViewNode::new(draw_ui_graph::NAME),
             );
-            graph_2d
-                .add_node_edge(
-                    bevy::core_pipeline::core_2d::graph::node::MAIN_PASS,
-                    draw_ui_graph::node::MAIN_PASS,
-                )
-                .unwrap();
-            graph_2d
-                .add_slot_edge(
-                    graph_2d.input_node().unwrap().id,
-                    bevy::core_pipeline::core_2d::graph::input::VIEW_ENTITY,
-                    draw_ui_graph::node::MAIN_PASS,
-                    RunGraphOnViewNode::IN_VIEW,
-                )
-                .unwrap();
-            graph_2d
-                .add_node_edge(
-                    bevy::core_pipeline::core_2d::graph::node::TONEMAPPING,
-                    draw_ui_graph::node::MAIN_PASS,
-                )
-                .unwrap();
-            graph_2d
-                .add_node_edge(
-                    draw_ui_graph::node::MAIN_PASS,
-                    bevy::core_pipeline::core_2d::graph::node::UPSCALING,
-                )
-                .unwrap();
+            graph_2d.add_node_edge(
+                bevy::core_pipeline::core_2d::graph::node::MAIN_PASS,
+                draw_ui_graph::node::MAIN_PASS,
+            );
+            graph_2d.add_slot_edge(
+                graph_2d.input_node().id,
+                bevy::core_pipeline::core_2d::graph::input::VIEW_ENTITY,
+                draw_ui_graph::node::MAIN_PASS,
+                RunGraphOnViewNode::IN_VIEW,
+            );
+            graph_2d.add_node_edge(
+                bevy::core_pipeline::core_2d::graph::node::TONEMAPPING,
+                draw_ui_graph::node::MAIN_PASS,
+            );
+            graph_2d.add_node_edge(
+                draw_ui_graph::node::MAIN_PASS,
+                bevy::core_pipeline::core_2d::graph::node::UPSCALING,
+            );
         }
 
         if let Some(graph_3d) = graph.get_sub_graph_mut(bevy::core_pipeline::core_3d::graph::NAME) {
@@ -112,32 +104,24 @@ impl Plugin for BevyKayakUIRenderPlugin {
                 draw_ui_graph::node::MAIN_PASS,
                 RunGraphOnViewNode::new(draw_ui_graph::NAME),
             );
-            graph_3d
-                .add_node_edge(
-                    bevy::core_pipeline::core_3d::graph::node::MAIN_PASS,
-                    draw_ui_graph::node::MAIN_PASS,
-                )
-                .unwrap();
-            graph_3d
-                .add_node_edge(
-                    bevy::core_pipeline::core_3d::graph::node::TONEMAPPING,
-                    draw_ui_graph::node::MAIN_PASS,
-                )
-                .unwrap();
-            graph_3d
-                .add_node_edge(
-                    draw_ui_graph::node::MAIN_PASS,
-                    bevy::core_pipeline::core_3d::graph::node::UPSCALING,
-                )
-                .unwrap();
-            graph_3d
-                .add_slot_edge(
-                    graph_3d.input_node().unwrap().id,
-                    bevy::core_pipeline::core_3d::graph::input::VIEW_ENTITY,
-                    draw_ui_graph::node::MAIN_PASS,
-                    RunGraphOnViewNode::IN_VIEW,
-                )
-                .unwrap();
+            graph_3d.add_node_edge(
+                bevy::core_pipeline::core_3d::graph::node::MAIN_PASS,
+                draw_ui_graph::node::MAIN_PASS,
+            );
+            graph_3d.add_node_edge(
+                bevy::core_pipeline::core_3d::graph::node::TONEMAPPING,
+                draw_ui_graph::node::MAIN_PASS,
+            );
+            graph_3d.add_node_edge(
+                draw_ui_graph::node::MAIN_PASS,
+                bevy::core_pipeline::core_3d::graph::node::UPSCALING,
+            );
+            graph_3d.add_slot_edge(
+                graph_3d.input_node().id,
+                bevy::core_pipeline::core_3d::graph::input::VIEW_ENTITY,
+                draw_ui_graph::node::MAIN_PASS,
+                RunGraphOnViewNode::IN_VIEW,
+            );
         }
 
         app.add_plugin(font::TextRendererPlugin)
@@ -154,14 +138,12 @@ fn get_ui_graph(render_app: &mut App) -> RenderGraph {
         draw_ui_graph::input::VIEW_ENTITY,
         SlotType::Entity,
     )]);
-    ui_graph
-        .add_slot_edge(
-            input_node_id,
-            draw_ui_graph::input::VIEW_ENTITY,
-            draw_ui_graph::node::MAIN_PASS,
-            MainPassUINode::IN_VIEW,
-        )
-        .unwrap();
+    ui_graph.add_slot_edge(
+        input_node_id,
+        draw_ui_graph::input::VIEW_ENTITY,
+        draw_ui_graph::node::MAIN_PASS,
+        MainPassUINode::IN_VIEW,
+    );
     ui_graph
 }
 

--- a/src/render/ui_pass.rs
+++ b/src/render/ui_pass.rs
@@ -5,7 +5,7 @@ use bevy::render::render_phase::{DrawFunctionId, PhaseItem};
 use bevy::render::render_resource::CachedRenderPipelineId;
 use bevy::render::{
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
-    render_phase::{DrawFunctions, RenderPhase, TrackedRenderPass},
+    render_phase::{DrawFunctions, RenderPhase},
     render_resource::{LoadOp, Operations, RenderPassDescriptor},
     renderer::RenderContext,
     view::{ExtractedView, ViewTarget},
@@ -32,6 +32,10 @@ impl PhaseItem for TransparentUI {
     #[inline]
     fn draw_function(&self) -> DrawFunctionId {
         self.draw_function
+    }
+
+    fn entity(&self) -> Entity {
+        self.entity
     }
 }
 
@@ -100,11 +104,8 @@ impl Node for MainPassUINode {
                 .get_resource::<DrawFunctions<TransparentUI>>()
                 .unwrap();
 
-            let render_pass = render_context
-                .command_encoder
-                .begin_render_pass(&pass_descriptor);
+            let mut tracked_pass = render_context.begin_tracked_render_pass(pass_descriptor);
             let mut draw_functions = draw_functions.write();
-            let mut tracked_pass = TrackedRenderPass::new(render_pass);
             for item in transparent_phase.items.iter() {
                 let draw_function = draw_functions.get_mut(item.draw_function).unwrap();
                 draw_function.draw(world, &mut tracked_pass, view_entity, item);

--- a/src/render/unified/pipeline.rs
+++ b/src/render/unified/pipeline.rs
@@ -185,6 +185,7 @@ impl FromWorld for UnifiedPipeline {
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
+            view_formats: &[TextureFormat::Rgba8UnormSrgb],
             format: TextureFormat::Rgba8UnormSrgb,
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
         };
@@ -209,6 +210,7 @@ impl FromWorld for UnifiedPipeline {
             texture,
             sampler,
             texture_view,
+            mip_level_count: 1,
             size: Vec2::new(1.0, 1.0),
             texture_format: TextureFormat::Rgba8UnormSrgb,
         };
@@ -298,12 +300,12 @@ impl SpecializedRenderPipeline for UnifiedPipeline {
                     write_mask: ColorWrites::ALL,
                 })],
             }),
-            layout: Some(vec![
+            layout: vec![
                 self.view_layout.clone(),
                 self.font_image_layout.clone(),
                 self.types_layout.clone(),
                 self.image_layout.clone(),
-            ]),
+            ],
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: None,
@@ -320,6 +322,7 @@ impl SpecializedRenderPipeline for UnifiedPipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some("unified_pipeline".into()),
+            push_constant_ranges: vec![],
         }
     }
 }
@@ -562,7 +565,7 @@ pub fn queue_quads(
             layout: &quad_pipeline.view_layout,
         }));
 
-        let key = UnifiedPipelineKey::from_msaa_samples(msaa.samples);
+        let key = UnifiedPipelineKey::from_msaa_samples(msaa.samples());
         let spec_pipeline = pipelines.specialize(&mut pipeline_cache, &quad_pipeline, key);
 
         let draw_quad = draw_functions.read().get_id::<DrawUI>().unwrap();

--- a/src/render/unified/shader.wgsl
+++ b/src/render/unified/shader.wgsl
@@ -53,7 +53,7 @@ var image_texture: texture_2d<f32>;
 @group(3) @binding(1)
 var image_sampler: sampler;
 
-let RADIUS: f32 = 0.1;
+const RADIUS: f32 = 0.1;
 
 // Where P is the position in pixel space, B is the size of the box adn R is the radius of the current corner.
 fn sdRoundBox(p: vec2<f32>, b: vec2<f32>, r: f32) -> f32 {

--- a/src/render/unified/text.rs
+++ b/src/render/unified/text.rs
@@ -1,10 +1,10 @@
 use bevy::{
-    prelude::{Plugin, Res, ResMut},
+    prelude::{IntoSystemConfig, Plugin, Res, ResMut},
     render::{
         render_asset::RenderAssets,
         renderer::{RenderDevice, RenderQueue},
         texture::Image,
-        RenderApp, RenderStage,
+        RenderApp, RenderSet,
     },
 };
 use kayak_font::bevy::{FontTextureCache, KayakFontPlugin};
@@ -19,7 +19,7 @@ impl Plugin for TextRendererPlugin {
         app.add_plugin(KayakFontPlugin);
 
         let render_app = app.sub_app_mut(RenderApp);
-        render_app.add_system_to_stage(RenderStage::Queue, create_and_update_font_cache_texture);
+        render_app.add_system(create_and_update_font_cache_texture.in_set(RenderSet::Queue));
     }
 }
 fn create_and_update_font_cache_texture(

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -7,7 +7,7 @@ use kayak_ui_macros::rsx;
 
 use crate::{
     context::WidgetName,
-    event::{Event, EventType},
+    event::{EventType, KEvent},
     event_dispatcher::EventDispatcherContext,
     on_event::OnEvent,
     prelude::{KChildren, KayakWidgetContext, Units},
@@ -92,7 +92,7 @@ pub fn button_render(
                 move |In((event_dispatcher_context, _, mut event, _entity)): In<(
                     EventDispatcherContext,
                     WidgetState,
-                    Event,
+                    KEvent,
                     Entity,
                 )>,
                       mut query: Query<&mut ButtonState>| {

--- a/src/widgets/scroll/scroll_bar.rs
+++ b/src/widgets/scroll/scroll_bar.rs
@@ -3,7 +3,7 @@ use kayak_ui_macros::rsx;
 
 use crate::{
     context::WidgetName,
-    event::{Event, EventType},
+    event::{EventType, KEvent},
     event_dispatcher::EventDispatcherContext,
     on_event::OnEvent,
     prelude::{KChildren, KayakWidgetContext},
@@ -206,7 +206,7 @@ pub fn scroll_bar_render(
                     move |In((mut event_dispatcher_context, _, mut event, _entity)): In<(
                         EventDispatcherContext,
                         WidgetState,
-                        Event,
+                        KEvent,
                         Entity,
                     )>,
                           mut query: Query<&mut ScrollContext>| {

--- a/src/widgets/scroll/scroll_box.rs
+++ b/src/widgets/scroll/scroll_box.rs
@@ -4,7 +4,7 @@ use crate::{
     children::KChildren,
     context::WidgetName,
     cursor::ScrollUnit,
-    event::{Event, EventType},
+    event::{EventType, KEvent},
     event_dispatcher::EventDispatcherContext,
     layout::{GeometryChanged, LayoutEvent},
     on_event::OnEvent,
@@ -185,7 +185,7 @@ pub fn scroll_box_render(
                     move |In((event_dispatcher_context, _, mut event, _entity)): In<(
                         EventDispatcherContext,
                         WidgetState,
-                        Event,
+                        KEvent,
                         Entity,
                     )>,
                           mut query: Query<&mut ScrollContext>| {

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -6,7 +6,7 @@ use kayak_ui_macros::{constructor, rsx};
 
 use crate::{
     context::WidgetName,
-    event::{Event, EventType},
+    event::{EventType, KEvent},
     event_dispatcher::EventDispatcherContext,
     on_event::OnEvent,
     on_layout::OnLayout,
@@ -185,7 +185,7 @@ pub fn text_box_render(
                 move |In((event_dispatcher_context, _, mut event, _entity)): In<(
                     EventDispatcherContext,
                     WidgetState,
-                    Event,
+                    KEvent,
                     Entity,
                 )>,
                       font_assets: Res<Assets<KayakFont>>,

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -7,7 +7,7 @@ use kayak_ui_macros::rsx;
 use crate::{
     children::KChildren,
     context::WidgetName,
-    event::{Event, EventType},
+    event::{EventType, KEvent},
     event_dispatcher::EventDispatcherContext,
     on_event::OnEvent,
     prelude::KayakWidgetContext,
@@ -132,7 +132,7 @@ pub fn window_render(
                 move |In((event_dispatcher_context, _, mut event, _entity)): In<(
                     EventDispatcherContext,
                     WidgetState,
-                    Event,
+                    KEvent,
                     Entity,
                 )>,
                       mut query: Query<&mut KWindowState>,
@@ -226,7 +226,7 @@ pub fn window_render(
                                     move |In((mut event_dispatcher_context, _, mut event, entity)): In<(
                                         EventDispatcherContext,
                                         WidgetState,
-                                        Event,
+                                        KEvent,
                                         Entity,
                                     )>,
                                         mut query: Query<&mut KWindowState>| {

--- a/src/window_size.rs
+++ b/src/window_size.rs
@@ -10,32 +10,42 @@ pub struct WindowSize(pub f32, pub f32);
 pub fn update_window_size(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,
-    windows: Res<Windows>,
+    windows: Query<&Window>,
     mut window_size: ResMut<WindowSize>,
 ) {
-    let mut changed_window_ids = Vec::new();
+    let mut changed_windows = Vec::new();
     // handle resize events. latest events are handled first because we only want to resize each
     // window once
-    for event in window_resized_events.iter().rev() {
-        if changed_window_ids.contains(&event.id) {
+    for event in window_resized_events
+        .iter()
+        .collect::<Vec<_>>()
+        .iter()
+        .rev()
+    {
+        if changed_windows.contains(&event.window) {
             continue;
         }
 
-        changed_window_ids.push(event.id);
+        changed_windows.push(event.window);
     }
 
     // handle resize events. latest events are handled first because we only want to resize each
     // window once
-    for event in window_created_events.iter().rev() {
-        if changed_window_ids.contains(&event.id) {
+    for event in window_created_events
+        .iter()
+        .collect::<Vec<_>>()
+        .iter()
+        .rev()
+    {
+        if changed_windows.contains(&event.window) {
             continue;
         }
 
-        changed_window_ids.push(event.id);
+        changed_windows.push(event.window);
     }
 
-    for window_id in changed_window_ids {
-        if let Some(window) = windows.get(window_id) {
+    for window_entity in changed_windows {
+        if let Ok(window) = windows.get(window_entity) {
             let width = window.width();
             let height = window.height();
             *window_size = WindowSize(width, height);


### PR DESCRIPTION
This PR updates kayak_ui to bevy 0.10. Note that this doesn't fully utilize any of 0.10 properly yet. I also fixed some issues where the Cargo.toml didn't enable features kayak_ui depends on errors about duplicate license info. `Event` was renamed to `KEvent` to fix a name conflict with `bevy::prelude::*`

I tested all examples and tested it in my own game, sadly cargo won't let me run cargo test without crashing my system, so I'm not sure about the doc examples.