### PR TITLE
KButtonBundle's "styles" prop now accepts font_size

### DIFF
--- a/examples/simple_state.rs
+++ b/examples/simple_state.rs
@@ -1,3 +1,4 @@
+use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use kayak_ui::prelude::{widgets::*, *};
 
@@ -57,8 +58,8 @@ fn current_count_render(
                         ..Default::default()
                     }}
                     styles={KStyle {
-                        font_size: StyleProp::Value(48.),
-                        height: StyleProp::Value(Units::Pixels(64.)),
+                        font_size: (48.).into(),
+                        height: Units::Pixels(64.).into(),
                         ..default()
                     }}
                     on_event={OnEvent::new(

--- a/examples/simple_state.rs
+++ b/examples/simple_state.rs
@@ -56,6 +56,11 @@ fn current_count_render(
                         text: "Click me!".into(),
                         ..Default::default()
                     }}
+                    styles={KStyle {
+                        font_size: StyleProp::Value(48.),
+                        height: StyleProp::Value(Units::Pixels(64.)),
+                        ..default()
+                    }}
                     on_event={OnEvent::new(
                         move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
                             mut query: Query<&mut CurrentCountState>| {

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -61,7 +61,19 @@ pub fn button_render(
 ) -> bool {
     if let Ok((button, styles, mut computed_styles)) = query.get_mut(entity) {
         let hover_color = Color::rgba(0.592, 0.627, 0.749, 1.0); //Color::rgba(0.549, 0.666, 0.933, 1.0);
-                                                                 // let color = Color::rgba(0.254, 0.270, 0.349, 1.0);
+
+        let font_size = if let StyleProp::Value(font_size) = styles.font_size {
+            font_size
+        } else {
+            16.
+        };
+
+        let height = if let StyleProp::Value(height) = styles.height {
+            height
+        } else {
+            Units::Pixels(28.0)
+        };
+
         let state_entity =
             widget_context.use_state(&mut commands, entity, ButtonState { hovering: false });
 
@@ -81,7 +93,8 @@ pub fn button_render(
                     },
                     border: Edge::all(2.0).into(),
                     border_radius: StyleProp::Value(Corner::all(10.0)),
-                    height: StyleProp::Value(Units::Pixels(28.0)),
+                    font_size: StyleProp::Value(font_size).into(),
+                    height: StyleProp::Value(height),
                     width: Units::Stretch(1.0).into(),
                     cursor: StyleProp::Value(KCursorIcon(CursorIcon::Hand)),
                     ..Default::default()
@@ -128,12 +141,12 @@ pub fn button_render(
                             bottom: Units::Stretch(1.0).into(),
                             left: Units::Stretch(1.0).into(),
                             right: Units::Stretch(1.0).into(),
+                            font_size: StyleProp::Value(font_size),
                             ..Default::default()
                         }}
                         text={TextProps {
                             alignment: Alignment::Start,
                             content: button.text.clone(),
-                            size: 16.0,
                             ..Default::default()
                         }}
                     />

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -62,17 +62,8 @@ pub fn button_render(
     if let Ok((button, styles, mut computed_styles)) = query.get_mut(entity) {
         let hover_color = Color::rgba(0.592, 0.627, 0.749, 1.0); //Color::rgba(0.549, 0.666, 0.933, 1.0);
 
-        let font_size = if let StyleProp::Value(font_size) = styles.font_size {
-            font_size
-        } else {
-            16.
-        };
-
-        let height = if let StyleProp::Value(height) = styles.height {
-            height
-        } else {
-            Units::Pixels(28.0)
-        };
+        let font_size = styles.font_size.resolve_or(16.);
+        let height = styles.height.resolve_or(Units::Pixels(28.));
 
         let state_entity =
             widget_context.use_state(&mut commands, entity, ButtonState { hovering: false });


### PR DESCRIPTION
fixes the following ( discord -> crate-help -> kayak_ui )
![image](https://user-images.githubusercontent.com/6434104/233711560-f061763b-5544-4873-b58d-41b80904bca2.png)


- `KButtonBundle`'s `styles` prop now accepts `font_size`
  - If not specified, the previously hardcoded value is used
- Also added `height` since the hardcoded value didn't let the text expand its parent
  - Same as `font_size`, 
- Added a `KStyle` with custom `font_size` to the `simple_state` example
