### PR TITLE
Resource instead of in

### DIFF
--- a/book/src/chapter_3.md
+++ b/book/src/chapter_3.md
@@ -56,8 +56,10 @@ impl Default for MyButtonBundle {
 
 pub fn my_button_render(
     // This is a bevy feature which allows custom parameters to be passed into a system.
-    // In this case Kayak UI gives the system a `KayakWidgetContext` and an `Entity`.
-    In((mut widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    // In this case Kayak UI gives the system an `Entity`.
+    In(entity): In<Entity>,
+    // This struct allows us to make changes to the widget tree.
+    mut widget_context: ResMut<KayakWidgetContext>,
     // The rest of the parameters are just like those found in a bevy system!
     // In fact you can add whatever you would like here including more queries or lookups
     // to resources within bevy's ECS.

--- a/examples/avsb.rs
+++ b/examples/avsb.rs
@@ -31,7 +31,8 @@ impl Default for CurrentCountBundle {
 }
 
 fn current_count_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&CurrentCountState>,
 ) -> bool {
@@ -110,7 +111,8 @@ impl Default for AvsBBundle {
 }
 
 fn render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&AvsBState>,
 ) -> bool {

--- a/examples/avsb.rs
+++ b/examples/avsb.rs
@@ -58,7 +58,8 @@ fn current_count_render(
                         ..Default::default()
                     }}
                     on_event={OnEvent::new(
-                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
+                        move |In(_entity): In<Entity>,
+                        mut event: ResMut<KEvent>,
                             mut query: Query<&mut CurrentCountState>| {
                             match event.event_type {
                                 EventType::Click(..) => {
@@ -70,7 +71,6 @@ fn current_count_render(
                                 }
                                 _ => {}
                             }
-                            (event_dispatcher_context, event)
                         },
                     )}
                 />

--- a/examples/bevy_scene.rs
+++ b/examples/bevy_scene.rs
@@ -183,12 +183,8 @@ fn startup(
     widget_context.add_plugin(KayakWidgetsContextPlugin);
 
     let handle_change_color = OnEvent::new(
-        move |In((event_dispatcher_context, _, event, _)): In<(
-            EventDispatcherContext,
-            WidgetState,
-            KEvent,
-            Entity,
-        )>,
+        move |In(_entity): In<Entity>,
+        event: Res<KEvent>,
               mut active_color: ResMut<ActiveColor>| {
             match event.event_type {
                 EventType::Click(..) => {
@@ -196,7 +192,6 @@ fn startup(
                 }
                 _ => {}
             }
-            (event_dispatcher_context, event)
         },
     );
 

--- a/examples/bevy_scene.rs
+++ b/examples/bevy_scene.rs
@@ -184,7 +184,7 @@ fn startup(
 
     let handle_change_color = OnEvent::new(
         move |In(_entity): In<Entity>,
-        event: Res<KEvent>,
+              event: Res<KEvent>,
               mut active_color: ResMut<ActiveColor>| {
             match event.event_type {
                 EventType::Click(..) => {

--- a/examples/conditional_widget.rs
+++ b/examples/conditional_widget.rs
@@ -49,7 +49,8 @@ fn my_widget_render(
                         text: "Show Window".into(),
                     }}
                     on_event={OnEvent::new(
-                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
+                        move |In(_entity): In<Entity>,
+                        mut event: ResMut<KEvent>,
                             mut query: Query<&mut MyWidgetState>| {
                             event.prevent_default();
                             event.stop_propagation();
@@ -61,7 +62,6 @@ fn my_widget_render(
                                 }
                                 _ => {}
                             }
-                            (event_dispatcher_context, event)
                         },
                     )}
                 />
@@ -79,7 +79,8 @@ fn my_widget_render(
                             <KButtonBundle
                                 button={KButton { text: "Hide Window".into(), ..Default::default() }}
                                 on_event={OnEvent::new(
-                                    move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
+                                    move |In(_entity): In<Entity>,
+                                    mut event: ResMut<KEvent>,
                                         mut query: Query<&mut MyWidgetState>| {
                                         match event.event_type {
                                             EventType::Click(..) => {
@@ -91,7 +92,6 @@ fn my_widget_render(
                                             }
                                             _ => {}
                                         }
-                                        (event_dispatcher_context, event)
                                     },
                                 )}
                             />

--- a/examples/conditional_widget.rs
+++ b/examples/conditional_widget.rs
@@ -29,7 +29,8 @@ impl Default for MyWidgetBundle {
 }
 
 fn my_widget_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&MyWidgetState>,
 ) -> bool {

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -70,7 +70,8 @@ impl Default for ThemeButtonBundle {
 }
 
 fn update_theme_button(
-    In((widget_context, theme_button_entity)): In<(KayakWidgetContext, Entity)>,
+    In(theme_button_entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&ThemeButton>,
     mut context_query: Query<&mut Theme>,
@@ -158,7 +159,8 @@ impl Default for ThemeSelectorBundle {
 }
 
 fn update_theme_selector(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&ThemeSelector>,
 ) -> bool {
@@ -213,7 +215,8 @@ impl Default for ThemeDemoBundle {
 }
 
 fn update_theme_demo(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query_set: Query<&mut ThemeDemo>,
     theme_context: Query<&Theme>,

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -102,12 +102,8 @@ fn update_theme_button(
                     <BackgroundBundle
                         styles={box_style}
                         on_event={OnEvent::new(
-                            move |In((event_dispatcher_context, _, event, _entity)): In<(
-                                EventDispatcherContext,
-                                WidgetState,
-                                KEvent,
-                                Entity,
-                            )>,
+                            move |In(_entity): In<Entity>,
+                            event: ResMut<KEvent>,
                             query: Query<&ThemeButton>,
                             mut context_query: Query<&mut Theme>,
                             | {
@@ -121,7 +117,6 @@ fn update_theme_button(
                                     },
                                     _ => {}
                                 }
-                                (event_dispatcher_context, event)
                             },
                         )}
                     />

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,7 +7,7 @@ pub struct MyWidget {
 }
 
 fn my_widget_1_render(
-    In((_widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
     mut _commands: Commands,
     query: Query<&MyWidget>,
 ) -> bool {

--- a/examples/main_menu.rs
+++ b/examples/main_menu.rs
@@ -32,7 +32,8 @@ impl Default for MenuButtonBundle {
 }
 
 fn menu_button_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     menu_button_query: Query<&MenuButton>,

--- a/examples/main_menu.rs
+++ b/examples/main_menu.rs
@@ -47,12 +47,8 @@ fn menu_button_render(
     let button_image_hover = asset_server.load("main_menu/button-hover.png");
 
     let on_event = OnEvent::new(
-        move |In((event_dispatcher_context, _, mut event, _entity)): In<(
-            EventDispatcherContext,
-            WidgetState,
-            KEvent,
-            Entity,
-        )>,
+        move |In(_entity): In<Entity>,
+        mut event: ResMut<KEvent>,
               mut query: Query<&mut ButtonState>| {
             if let Ok(mut button) = query.get_mut(state_entity) {
                 match event.event_type {
@@ -66,7 +62,6 @@ fn menu_button_render(
                     _ => {}
                 }
             }
-            (event_dispatcher_context, event)
         },
     );
 
@@ -153,12 +148,8 @@ fn startup(
     ]);
 
     let handle_click_close = OnEvent::new(
-        move |In((event_dispatcher_context, _, event, _entity)): In<(
-            EventDispatcherContext,
-            WidgetState,
-            KEvent,
-            Entity,
-        )>,
+        move |In(_entity): In<Entity>,
+        event: ResMut<KEvent>,
               mut exit: EventWriter<AppExit>| {
             match event.event_type {
                 EventType::Click(..) => {
@@ -166,7 +157,6 @@ fn startup(
                 }
                 _ => {}
             }
-            (event_dispatcher_context, event)
         },
     );
 

--- a/examples/main_menu.rs
+++ b/examples/main_menu.rs
@@ -48,7 +48,7 @@ fn menu_button_render(
 
     let on_event = OnEvent::new(
         move |In(_entity): In<Entity>,
-        mut event: ResMut<KEvent>,
+              mut event: ResMut<KEvent>,
               mut query: Query<&mut ButtonState>| {
             if let Ok(mut button) = query.get_mut(state_entity) {
                 match event.event_type {
@@ -148,9 +148,7 @@ fn startup(
     ]);
 
     let handle_click_close = OnEvent::new(
-        move |In(_entity): In<Entity>,
-        event: ResMut<KEvent>,
-              mut exit: EventWriter<AppExit>| {
+        move |In(_entity): In<Entity>, event: ResMut<KEvent>, mut exit: EventWriter<AppExit>| {
             match event.event_type {
                 EventType::Click(..) => {
                     exit.send(AppExit);

--- a/examples/modal.rs
+++ b/examples/modal.rs
@@ -49,7 +49,8 @@ fn my_widget_render(
                         text: "Show Modal".into(),
                     }}
                     on_event={OnEvent::new(
-                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
+                        move |In(_entity): In<Entity>,
+                        mut event: ResMut<KEvent>,
                             mut query: Query<&mut MyWidgetState>| {
                             event.prevent_default();
                             event.stop_propagation();
@@ -61,7 +62,6 @@ fn my_widget_render(
                                 }
                                 _ => {}
                             }
-                            (event_dispatcher_context, event)
                         },
                     )}
                 />
@@ -82,7 +82,8 @@ fn my_widget_render(
                     <KButtonBundle
                         button={KButton { text: "Hide Window".into(), ..Default::default() }}
                         on_event={OnEvent::new(
-                            move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
+                            move |In(_entity): In<Entity>,
+                            mut event: ResMut<KEvent>,
                                 mut query: Query<&mut MyWidgetState>| {
                                 match event.event_type {
                                     EventType::Click(..) => {
@@ -94,7 +95,6 @@ fn my_widget_render(
                                     }
                                     _ => {}
                                 }
-                                (event_dispatcher_context, event)
                             },
                         )}
                     />

--- a/examples/modal.rs
+++ b/examples/modal.rs
@@ -29,7 +29,8 @@ impl Default for MyWidgetBundle {
 }
 
 fn my_widget_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&MyWidgetState>,
 ) -> bool {

--- a/examples/quads.rs
+++ b/examples/quads.rs
@@ -36,12 +36,8 @@ fn my_quad_update(
             .into();
 
         *on_event = OnEvent::new(
-            move |In((event_dispatcher_context, _, mut event, entity)): In<(
-                EventDispatcherContext,
-                WidgetState,
-                KEvent,
-                Entity,
-            )>,
+            move |In(_entity): In<Entity>,
+                mut event: ResMut<KEvent>,
                   mut query: Query<(&mut KStyle, &MyQuad)>| {
                 event.prevent_default();
                 event.stop_propagation();
@@ -58,7 +54,6 @@ fn my_quad_update(
                     }
                     _ => {}
                 }
-                (event_dispatcher_context, event)
             },
         );
     }

--- a/examples/quads.rs
+++ b/examples/quads.rs
@@ -37,7 +37,7 @@ fn my_quad_update(
 
         *on_event = OnEvent::new(
             move |In(_entity): In<Entity>,
-                mut event: ResMut<KEvent>,
+                  mut event: ResMut<KEvent>,
                   mut query: Query<(&mut KStyle, &MyQuad)>| {
                 event.prevent_default();
                 event.stop_propagation();

--- a/examples/quads.rs
+++ b/examples/quads.rs
@@ -13,7 +13,7 @@ pub struct MyQuad {
 }
 
 fn my_quad_update(
-    In((_widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
     mut query: Query<(&MyQuad, &KStyle, &mut ComputedStyles, &mut OnEvent)>,
 ) -> bool {
     if let Ok((quad, style, mut computed_styles, mut on_event)) = query.get_mut(entity) {

--- a/examples/simple_state.rs
+++ b/examples/simple_state.rs
@@ -63,7 +63,8 @@ fn current_count_render(
                         ..default()
                     }}
                     on_event={OnEvent::new(
-                        move |In((event_dispatcher_context, _, mut event, _entity)): In<(EventDispatcherContext, WidgetState, KEvent, Entity)>,
+                        move |In(_entity): In<Entity>,
+                        mut event: ResMut<KEvent>,
                             mut query: Query<&mut CurrentCountState>| {
                             match event.event_type {
                                 EventType::Click(..) => {
@@ -75,7 +76,6 @@ fn current_count_render(
                                 }
                                 _ => {}
                             }
-                            (event_dispatcher_context, event)
                         },
                     )}
                 />

--- a/examples/simple_state.rs
+++ b/examples/simple_state.rs
@@ -31,7 +31,8 @@ impl Default for CurrentCountBundle {
 }
 
 fn current_count_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&CurrentCountState>,
 ) -> bool {

--- a/examples/tabs/tab.rs
+++ b/examples/tabs/tab.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query};
+use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res};
 use kayak_ui::prelude::{
     rsx, widgets::BackgroundBundle, ComputedStyles, Edge, KChildren, KStyle, KayakWidgetContext,
     StyleProp, Units, Widget, WidgetName,
@@ -33,7 +33,8 @@ impl Default for TabBundle {
 }
 
 pub fn tab_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KChildren, &Tab, &mut ComputedStyles)>,
     tab_context_query: Query<&TabContext>,

--- a/examples/tabs/tab_button.rs
+++ b/examples/tabs/tab_button.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query};
+use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res};
 use kayak_ui::{
     prelude::{
         rsx, widgets::KButtonBundle, Corner, EventDispatcherContext, EventType, KEvent, KStyle,
@@ -35,7 +35,8 @@ impl Default for TabButtonBundle {
 }
 
 pub fn tab_button_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<&TabButton>,
     tab_context_query: Query<&mut TabContext>,

--- a/examples/tabs/tab_button.rs
+++ b/examples/tabs/tab_button.rs
@@ -1,8 +1,8 @@
 use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res};
 use kayak_ui::{
     prelude::{
-        rsx, widgets::KButtonBundle, Corner, EventDispatcherContext, EventType, KEvent, KStyle,
-        KayakWidgetContext, OnEvent, StyleProp, Units, Widget, WidgetName, WidgetState,
+        rsx, widgets::KButtonBundle, Corner, EventType, KEvent, KStyle,
+        KayakWidgetContext, OnEvent, StyleProp, Units, Widget, WidgetName
     },
     widgets::KButton,
 };
@@ -55,12 +55,8 @@ pub fn tab_button_render(
 
             let button_index = tab_button.index;
             let on_event = OnEvent::new(
-                move |In((event_dispatcher_context, _, event, _entity)): In<(
-                    EventDispatcherContext,
-                    WidgetState,
-                    KEvent,
-                    Entity,
-                )>,
+                move |In(_entity): In<Entity>,
+                event: Res<KEvent>,
                       mut query: Query<&mut TabContext>| {
                     match event.event_type {
                         EventType::Click(..) => {
@@ -70,7 +66,6 @@ pub fn tab_button_render(
                         }
                         _ => {}
                     }
-                    (event_dispatcher_context, event)
                 },
             );
 

--- a/examples/tabs/tab_button.rs
+++ b/examples/tabs/tab_button.rs
@@ -1,8 +1,8 @@
 use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res};
 use kayak_ui::{
     prelude::{
-        rsx, widgets::KButtonBundle, Corner, EventType, KEvent, KStyle,
-        KayakWidgetContext, OnEvent, StyleProp, Units, Widget, WidgetName
+        rsx, widgets::KButtonBundle, Corner, EventType, KEvent, KStyle, KayakWidgetContext,
+        OnEvent, StyleProp, Units, Widget, WidgetName,
     },
     widgets::KButton,
 };
@@ -56,7 +56,7 @@ pub fn tab_button_render(
             let button_index = tab_button.index;
             let on_event = OnEvent::new(
                 move |In(_entity): In<Entity>,
-                event: Res<KEvent>,
+                      event: Res<KEvent>,
                       mut query: Query<&mut TabContext>| {
                     match event.event_type {
                         EventType::Click(..) => {

--- a/examples/tabs/tab_context.rs
+++ b/examples/tabs/tab_context.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query};
+use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, Res};
 use kayak_ui::prelude::*;
 
 #[derive(Component, Default, PartialEq, Eq, Clone)]
@@ -35,7 +35,8 @@ impl Default for TabContextProviderBundle {
 }
 
 pub fn tab_context_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<(&KChildren, &TabContextProvider)>,
 ) -> bool {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -7,7 +7,7 @@ pub struct MyWidgetProps {
 }
 
 fn my_widget_1_render(
-    In((_widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
     my_resource: Res<MyResource>,
     mut query: Query<(&mut MyWidgetProps, &KStyle, &mut ComputedStyles)>,
 ) -> bool {
@@ -37,7 +37,8 @@ pub fn widget_update_with_resource<
     Props: PartialEq + Component + Clone,
     State: PartialEq + Component + Clone,
 >(
-    In((widget_context, entity, previous_entity)): In<(KayakWidgetContext, Entity, Entity)>,
+    In((entity, previous_entity)): In<(Entity, Entity)>,
+    widget_context: Res<KayakWidgetContext>,
     my_resource: Res<MyResource>,
     widget_param: WidgetParam<Props, State>,
 ) -> bool {

--- a/examples/text_box.rs
+++ b/examples/text_box.rs
@@ -30,7 +30,8 @@ impl Default for TextBoxExampleBundle {
 }
 
 fn update_text_box_example(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     state_query: Query<&TextBoxExampleState>,
 ) -> bool {

--- a/examples/text_box.rs
+++ b/examples/text_box.rs
@@ -46,7 +46,7 @@ fn update_text_box_example(
 
     if let Ok(textbox_state) = state_query.get(state_entity) {
         let on_change = OnChange::new(
-            move |In((_widget_context, _, value)): In<(KayakWidgetContext, Entity, String)>,
+            move |In((_, value)): In<(Entity, String)>,
                   mut state_query: Query<&mut TextBoxExampleState>| {
                 if let Ok(mut state) = state_query.get_mut(state_entity) {
                     state.value1 = value;
@@ -55,7 +55,7 @@ fn update_text_box_example(
         );
 
         let on_change2 = OnChange::new(
-            move |In((_widget_context, _, value)): In<(KayakWidgetContext, Entity, String)>,
+            move |In((_, value)): In<(Entity, String)>,
                   mut state_query: Query<&mut TextBoxExampleState>| {
                 if let Ok(mut state) = state_query.get_mut(state_entity) {
                     state.value2 = value;

--- a/examples/todo/input.rs
+++ b/examples/todo/input.rs
@@ -50,9 +50,7 @@ pub fn render_todo_input(
     );
 
     let handle_click = OnEvent::new(
-            move |In(_entity): In<Entity>,
-            event: Res<KEvent>,
-              mut todo_list: ResMut<TodoList>| {
+        move |In(_entity): In<Entity>, event: Res<KEvent>, mut todo_list: ResMut<TodoList>| {
             match event.event_type {
                 EventType::Click(..) => {
                     if !todo_list.new_item.is_empty() {

--- a/examples/todo/input.rs
+++ b/examples/todo/input.rs
@@ -37,7 +37,8 @@ impl Default for TodoInputBundle {
 }
 
 pub fn render_todo_input(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     todo_list: Res<TodoList>,
 ) -> bool {

--- a/examples/todo/input.rs
+++ b/examples/todo/input.rs
@@ -43,8 +43,7 @@ pub fn render_todo_input(
     todo_list: Res<TodoList>,
 ) -> bool {
     let on_change = OnChange::new(
-        move |In((_widget_context, _, value)): In<(KayakWidgetContext, Entity, String)>,
-              mut todo_list: ResMut<TodoList>| {
+        move |In((_, value)): In<(Entity, String)>, mut todo_list: ResMut<TodoList>| {
             todo_list.new_item = value;
         },
     );

--- a/examples/todo/input.rs
+++ b/examples/todo/input.rs
@@ -50,12 +50,8 @@ pub fn render_todo_input(
     );
 
     let handle_click = OnEvent::new(
-        move |In((event_dispatcher_context, _, event, _)): In<(
-            EventDispatcherContext,
-            WidgetState,
-            KEvent,
-            Entity,
-        )>,
+            move |In(_entity): In<Entity>,
+            event: Res<KEvent>,
               mut todo_list: ResMut<TodoList>| {
             match event.event_type {
                 EventType::Click(..) => {
@@ -67,7 +63,6 @@ pub fn render_todo_input(
                 }
                 _ => {}
             }
-            (event_dispatcher_context, event)
         },
     );
 

--- a/examples/todo/items.rs
+++ b/examples/todo/items.rs
@@ -48,12 +48,8 @@ pub fn render_todo_items(
         >
             {todo_list.items.iter().enumerate().for_each(|(index, content)| {
                 let handle_click = OnEvent::new(
-                    move |In((event_dispatcher_context, _, event, _)): In<(
-                        EventDispatcherContext,
-                        WidgetState,
-                        KEvent,
-                        Entity,
-                    )>,
+                    move |In(_entity): In<Entity>,
+                          event: Res<KEvent>,
                         mut todo_list: ResMut<TodoList>,| {
                         match event.event_type {
                             EventType::Click(..) => {
@@ -61,7 +57,6 @@ pub fn render_todo_items(
                             },
                             _ => {}
                         }
-                        (event_dispatcher_context, event)
                     },
                 );
                 constructor! {

--- a/examples/todo/items.rs
+++ b/examples/todo/items.rs
@@ -33,7 +33,8 @@ impl Default for TodoItemsBundle {
 }
 
 pub fn render_todo_items(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     todo_list: Res<TodoList>,
 ) -> bool {

--- a/examples/todo/todo.rs
+++ b/examples/todo/todo.rs
@@ -41,7 +41,8 @@ pub fn widget_update_with_resource<
     Props: PartialEq + Component + Clone,
     State: PartialEq + Component + Clone,
 >(
-    In((widget_context, entity, previous_entity)): In<(KayakWidgetContext, Entity, Entity)>,
+    In((entity, previous_entity)): In<(Entity, Entity)>,
+    widget_context: Res<KayakWidgetContext>,
     todo_list: Res<TodoList>,
     widget_param: WidgetParam<Props, State>,
 ) -> bool {

--- a/examples/transitions.rs
+++ b/examples/transitions.rs
@@ -10,7 +10,8 @@ pub struct MyQuad {
 }
 
 fn my_quad_update(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<&MyQuad>,
 ) -> bool {

--- a/examples/vec.rs
+++ b/examples/vec.rs
@@ -5,7 +5,8 @@ use kayak_ui::prelude::{widgets::*, *};
 pub struct MyWidgetProps {}
 
 fn my_widget_1_update(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     query: Query<Entity, Or<(With<Mounted>, Changed<MyWidgetProps>)>>,
 ) -> bool {

--- a/src/context.rs
+++ b/src/context.rs
@@ -992,16 +992,15 @@ fn update_widget(
             ))
             .0;
         let old_tick = widget_update_system.get_last_change_tick();
-        
+
         // Insert context as a bevy resource.
         world.insert_resource(widget_context);
-        let should_rerender =
-            widget_update_system.run((entity.0, old_props_entity), world);
+        let should_rerender = widget_update_system.run((entity.0, old_props_entity), world);
         let new_tick = widget_update_system.get_last_change_tick();
         new_ticks.insert(widget_type.clone(), new_tick);
         widget_update_system.set_last_change_tick(old_tick);
         widget_update_system.apply_buffers(world);
-        
+
         // Extract context
         widget_context = world.remove_resource::<KayakWidgetContext>().unwrap();
 
@@ -1083,8 +1082,7 @@ fn update_widget(
         let widget_render_system = &mut systems.get_mut(&widget_type).unwrap().1;
         let old_tick = widget_render_system.get_last_change_tick();
         world.insert_resource(widget_context.clone());
-        should_update_children =
-            widget_render_system.run(entity.0, world);
+        should_update_children = widget_render_system.run(entity.0, world);
         let new_tick = widget_render_system.get_last_change_tick();
         new_ticks.insert(widget_type.clone(), new_tick);
         widget_render_system.set_last_change_tick(old_tick);

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,8 +42,8 @@ const UPDATE_DEPTH: u32 = 0;
 type WidgetSystems = HashMap<
     String,
     (
-        Box<dyn System<In = (KayakWidgetContext, Entity, Entity), Out = bool>>,
-        Box<dyn System<In = (KayakWidgetContext, Entity), Out = bool>>,
+        Box<dyn System<In = (Entity, Entity), Out = bool>>,
+        Box<dyn System<In = Entity, Out = bool>>,
     ),
 >;
 
@@ -171,8 +171,8 @@ impl KayakRootContext {
     pub fn add_widget_system<Params, Params2>(
         &mut self,
         type_name: impl Into<String>,
-        update: impl IntoSystem<(KayakWidgetContext, Entity, Entity), bool, Params>,
-        render: impl IntoSystem<(KayakWidgetContext, Entity), bool, Params2>,
+        update: impl IntoSystem<(Entity, Entity), bool, Params>,
+        render: impl IntoSystem<Entity, bool, Params2>,
     ) {
         let type_name = type_name.into();
         let update_system = Box::new(IntoSystem::into_system(update));
@@ -935,7 +935,7 @@ fn update_widget(
     world: &mut World,
     entity: WrappedIndex,
     widget_type: String,
-    widget_context: KayakWidgetContext,
+    mut widget_context: KayakWidgetContext,
     previous_children: Vec<Entity>,
     clone_systems: &Arc<RwLock<EntityCloneSystems>>,
     cloned_widget_entities: &Arc<RwLock<HashMap<Entity, Entity>>>,
@@ -992,12 +992,18 @@ fn update_widget(
             ))
             .0;
         let old_tick = widget_update_system.get_last_change_tick();
+        
+        // Insert context as a bevy resource.
+        world.insert_resource(widget_context);
         let should_rerender =
-            widget_update_system.run((widget_context.clone(), entity.0, old_props_entity), world);
+            widget_update_system.run((entity.0, old_props_entity), world);
         let new_tick = widget_update_system.get_last_change_tick();
         new_ticks.insert(widget_type.clone(), new_tick);
         widget_update_system.set_last_change_tick(old_tick);
         widget_update_system.apply_buffers(world);
+        
+        // Extract context
+        widget_context = world.remove_resource::<KayakWidgetContext>().unwrap();
 
         if should_rerender {
             if let Ok(cloned_widget_entities) = cloned_widget_entities.try_read() {
@@ -1076,12 +1082,14 @@ fn update_widget(
         widget_context.remove_children(previous_children);
         let widget_render_system = &mut systems.get_mut(&widget_type).unwrap().1;
         let old_tick = widget_render_system.get_last_change_tick();
+        world.insert_resource(widget_context.clone());
         should_update_children =
-            widget_render_system.run((widget_context.clone(), entity.0), world);
+            widget_render_system.run(entity.0, world);
         let new_tick = widget_render_system.get_last_change_tick();
         new_ticks.insert(widget_type.clone(), new_tick);
         widget_render_system.set_last_change_tick(old_tick);
         widget_render_system.apply_buffers(world);
+        world.remove_resource::<KayakWidgetContext>();
 
         if let Ok(mut indices) = widget_context.index.try_write() {
             indices.insert(entity.0, 0);

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Entity, World, Resource};
+use bevy::prelude::{Entity, Resource, World};
 
 use crate::{
     cursor::{CursorEvent, ScrollEvent},

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Entity, World};
+use bevy::prelude::{Entity, World, Resource};
 
 use crate::{
     cursor::{CursorEvent, ScrollEvent},
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// An event type sent to widgets
-#[derive(Clone)]
+#[derive(Resource, Clone)]
 pub struct KEvent {
     /// The node targeted by this event
     pub target: Entity,

--- a/src/event_dispatcher.rs
+++ b/src/event_dispatcher.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Component, Entity, KeyCode, World, Resource},
+    prelude::{Component, Entity, KeyCode, Resource, World},
     utils::{HashMap, HashSet},
 };
 

--- a/src/event_dispatcher.rs
+++ b/src/event_dispatcher.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Component, Entity, KeyCode, World},
+    prelude::{Component, Entity, KeyCode, World, Resource},
     utils::{HashMap, HashSet},
 };
 
@@ -866,6 +866,7 @@ impl EventDispatcher {
     }
 }
 
+#[derive(Resource)]
 pub struct EventDispatcherContext {
     cursor_capture: Option<WrappedIndex>,
 }

--- a/src/on_change.rs
+++ b/src/on_change.rs
@@ -16,7 +16,7 @@ pub trait ChangeValue: Component<Storage = TableStorage> + Default {}
 pub struct OnChange {
     value: Arc<RwLock<String>>,
     has_initialized: Arc<RwLock<bool>>,
-    system: Arc<RwLock<dyn System<In = (KayakWidgetContext, Entity, String), Out = ()>>>,
+    system: Arc<RwLock<dyn System<In = (Entity, String), Out = ()>>>,
 }
 
 impl Default for OnChange {
@@ -30,9 +30,7 @@ impl OnChange {
     ///
     /// The handler should be a closure that takes the following arguments:
     /// 1. The LayoutEvent
-    pub fn new<Params>(
-        system: impl IntoSystem<(KayakWidgetContext, Entity, String), (), Params>,
-    ) -> Self {
+    pub fn new<Params>(system: impl IntoSystem<(Entity, String), (), Params>) -> Self {
         Self {
             value: Default::default(),
             has_initialized: Arc::new(RwLock::new(false)),
@@ -57,7 +55,8 @@ impl OnChange {
                         system.initialize(world);
                         *init = true;
                     }
-                    system.run((widget_context, entity, value.clone()), world);
+                    world.insert_resource(widget_context);
+                    system.run((entity, value.clone()), world);
                     system.apply_buffers(world);
                 }
             }

--- a/src/on_event.rs
+++ b/src/on_event.rs
@@ -14,22 +14,12 @@ use crate::widget_state::WidgetState;
 #[derive(Component, Clone)]
 pub struct OnEvent {
     has_initialized: bool,
-    system: Arc<
-        RwLock<
-            dyn System<
-                In = Entity,
-                Out = (),
-            >,
-        >,
-    >,
+    system: Arc<RwLock<dyn System<In = Entity, Out = ()>>>,
 }
 
 impl Default for OnEvent {
     fn default() -> Self {
-        Self::new(
-            |In(_entity)| {
-            },
-        )
+        Self::new(|In(_entity)| {})
     }
 }
 
@@ -39,13 +29,7 @@ impl OnEvent {
     /// The handler should be a closure that takes the following arguments:
     /// 1. The current context
     /// 2. The event
-    pub fn new<Params>(
-        system: impl IntoSystem<
-            Entity,
-            (),
-            Params,
-        >,
-    ) -> OnEvent {
+    pub fn new<Params>(system: impl IntoSystem<Entity, (), Params>) -> OnEvent {
         Self {
             has_initialized: false,
             system: Arc::new(RwLock::new(IntoSystem::into_system(system))),
@@ -73,10 +57,7 @@ impl OnEvent {
             world.insert_resource(widget_state);
             world.insert_resource(event);
 
-            system.run(
-                entity,
-                world,
-            );
+            system.run(entity, world);
 
             event_dispatcher_context = world.remove_resource::<EventDispatcherContext>().unwrap();
             event = world.remove_resource::<KEvent>().unwrap();

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,6 +1,6 @@
 use bevy::{
     ecs::system::SystemParam,
-    prelude::{Changed, Component, Entity, In, Query, With},
+    prelude::{Changed, Component, Entity, In, Query, With, Res},
 };
 
 use crate::{
@@ -20,7 +20,8 @@ pub trait Widget: Send + Sync {
 pub struct EmptyState;
 
 pub fn widget_update<Props: PartialEq + Component + Clone, State: PartialEq + Component + Clone>(
-    In((widget_context, entity, previous_entity)): In<(KayakWidgetContext, Entity, Entity)>,
+    In((entity, previous_entity)): In<(Entity, Entity)>,
+    widget_context: Res<KayakWidgetContext>,
     widget_param: WidgetParam<Props, State>,
 ) -> bool {
     widget_param.has_changed(&widget_context, entity, previous_entity)
@@ -31,7 +32,8 @@ pub fn widget_update_with_context<
     State: PartialEq + Component + Clone,
     Context: PartialEq + Component + Clone + Default,
 >(
-    In((widget_context, entity, previous_entity)): In<(KayakWidgetContext, Entity, Entity)>,
+    In((entity, previous_entity)): In<(Entity, Entity)>,
+    widget_context: Res<KayakWidgetContext>,
     widget_param: WidgetParam<Props, State>,
     context_query: Query<Entity, Changed<Context>>,
 ) -> bool {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,6 +1,6 @@
 use bevy::{
     ecs::system::SystemParam,
-    prelude::{Changed, Component, Entity, In, Query, With, Res},
+    prelude::{Changed, Component, Entity, In, Query, Res, With},
 };
 
 use crate::{

--- a/src/widget_context.rs
+++ b/src/widget_context.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, RwLock};
 
 use bevy::{
-    prelude::{BuildChildren, Commands, Component, Entity},
+    prelude::{BuildChildren, Commands, Component, Entity, Resource},
     utils::HashMap,
 };
 use morphorm::Hierarchy;
@@ -17,7 +17,7 @@ use crate::{
 /// It has some knowledge about the existing tree and it knows about a subset of the new tree.
 /// It is not possible to create a KayakWidgetContext from scratch. One will be provided
 /// to the render system via it's In parameters.
-#[derive(Clone)]
+#[derive(Resource, Clone)]
 pub struct KayakWidgetContext {
     old_tree: Arc<RwLock<Tree>>,
     new_tree: Arc<RwLock<Tree>>,

--- a/src/widget_state.rs
+++ b/src/widget_state.rs
@@ -1,12 +1,12 @@
 use std::sync::{Arc, RwLock};
 
 use bevy::{
-    prelude::{BuildChildren, Commands, Component, Entity},
+    prelude::{BuildChildren, Commands, Component, Entity, Resource},
     utils::HashMap,
 };
 
 /// Stores mappings between widget entities and their corresponding state entities.
-#[derive(Default, Debug, Clone)]
+#[derive(Resource, Default, Debug, Clone)]
 pub struct WidgetState {
     // Widget entity to state entity
     mapping: Arc<RwLock<HashMap<Entity, Entity>>>,

--- a/src/widgets/accordion/context.rs
+++ b/src/widgets/accordion/context.rs
@@ -69,7 +69,8 @@ impl Default for AccordionContextBundle {
 }
 
 pub fn render(
-    In((widget_context, widget_entity)): In<(KayakWidgetContext, Entity)>,
+    In(widget_entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     children_query: Query<(&AccordionContextProvider, &KChildren)>,
 ) -> bool {

--- a/src/widgets/accordion/details.rs
+++ b/src/widgets/accordion/details.rs
@@ -42,7 +42,8 @@ impl Default for AccordionDetailsBundle {
 }
 
 pub fn render(
-    In((widget_context, accordion_widget)): In<(KayakWidgetContext, Entity)>,
+    In(accordion_widget): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&AccordionDetails, &KChildren)>,
     context_query: Query<&AccordionContext>,

--- a/src/widgets/accordion/summary.rs
+++ b/src/widgets/accordion/summary.rs
@@ -5,7 +5,6 @@ use crate::{
     children::KChildren,
     context::WidgetName,
     event::{EventType, KEvent},
-    event_dispatcher::EventDispatcherContext,
     on_event::OnEvent,
     prelude::KayakWidgetContext,
     styles::{
@@ -13,7 +12,6 @@ use crate::{
         Units,
     },
     widget::Widget,
-    widget_state::WidgetState,
     widgets::{
         BackgroundBundle, ElementBundle, KSvg, KSvgBundle, Svg, EXPAND_LESS_HANDLE,
         EXPAND_MORE_HANDLE,
@@ -77,12 +75,8 @@ pub fn render(
             if let Ok(context) = context_query.get(context_entity) {
                 let current_index = accordion.index;
                 let on_event = OnEvent::new(
-                    move |In((event_dispatcher_context, _, mut event, _entity)): In<(
-                        EventDispatcherContext,
-                        WidgetState,
-                        KEvent,
-                        Entity,
-                    )>,
+                    move |In(_entity): In<Entity>,
+                          mut event: ResMut<KEvent>,
                           mut query: Query<&mut AccordionContext>| {
                         if let Ok(mut context) = query.get_mut(context_entity) {
                             event.stop_propagation();
@@ -94,8 +88,6 @@ pub fn render(
                                 _ => {}
                             }
                         }
-
-                        (event_dispatcher_context, event)
                     },
                 );
 

--- a/src/widgets/accordion/summary.rs
+++ b/src/widgets/accordion/summary.rs
@@ -51,7 +51,8 @@ impl Default for AccordionSummaryBundle {
 }
 
 pub fn render(
-    In((widget_context, accordion_widget)): In<(KayakWidgetContext, Entity)>,
+    In(accordion_widget): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&AccordionSummary, &KChildren, &KStyle, &mut ComputedStyles)>,
     context_query: Query<&AccordionContext>,

--- a/src/widgets/app.rs
+++ b/src/widgets/app.rs
@@ -42,7 +42,8 @@ impl Default for KayakAppBundle {
 }
 
 pub fn app_update(
-    In((widget_context, entity, previous_props_entity)): In<(KayakWidgetContext, Entity, Entity)>,
+    In((entity, previous_props_entity)): In<(Entity, Entity)>,
+    widget_context: Res<KayakWidgetContext>,
     widget_param: WidgetParam<KayakApp, EmptyState>,
     camera: Query<&Camera, With<CameraUIKayak>>,
     windows: Query<&Window, With<PrimaryWindow>>,
@@ -80,7 +81,8 @@ pub fn app_update(
 
 /// TODO: USE CAMERA INSTEAD OF WINDOW!!
 pub fn app_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KChildren)>,
     camera: Query<&Camera, With<CameraUIKayak>>,

--- a/src/widgets/app.rs
+++ b/src/widgets/app.rs
@@ -82,7 +82,7 @@ pub fn app_update(
 /// TODO: USE CAMERA INSTEAD OF WINDOW!!
 pub fn app_render(
     In(entity): In<Entity>,
-widget_context: Res<KayakWidgetContext>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KChildren)>,
     camera: Query<&Camera, With<CameraUIKayak>>,

--- a/src/widgets/background.rs
+++ b/src/widgets/background.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query};
+use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, Res};
 
 use crate::{
     children::KChildren,
@@ -44,7 +44,8 @@ impl Default for BackgroundBundle {
 }
 
 pub fn background_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KChildren)>,
 ) -> bool {

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -8,12 +8,10 @@ use kayak_ui_macros::rsx;
 use crate::{
     context::WidgetName,
     event::{EventType, KEvent},
-    event_dispatcher::EventDispatcherContext,
     on_event::OnEvent,
     prelude::{KChildren, KayakWidgetContext, Units},
     styles::{ComputedStyles, Corner, Edge, KCursorIcon, KStyle, RenderCommand, StyleProp},
     widget::Widget,
-    widget_state::WidgetState,
 };
 
 use super::{ElementBundle, TextProps, TextWidgetBundle};
@@ -94,12 +92,8 @@ pub fn button_render(
                 .into();
 
             let on_event = OnEvent::new(
-                move |In((event_dispatcher_context, _, mut event, _entity)): In<(
-                    EventDispatcherContext,
-                    WidgetState,
-                    KEvent,
-                    Entity,
-                )>,
+                    move |In(_entity): In<Entity>,
+                    mut event: ResMut<KEvent>,
                       mut query: Query<&mut ButtonState>| {
                     if let Ok(mut button) = query.get_mut(state_entity) {
                         match event.event_type {
@@ -113,7 +107,6 @@ pub fn button_render(
                             _ => {}
                         }
                     }
-                    (event_dispatcher_context, event)
                 },
             );
 

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -1,7 +1,4 @@
-use bevy::{
-    prelude::*,
-    window::CursorIcon,
-};
+use bevy::{prelude::*, window::CursorIcon};
 use kayak_font::Alignment;
 use kayak_ui_macros::rsx;
 
@@ -92,8 +89,8 @@ pub fn button_render(
                 .into();
 
             let on_event = OnEvent::new(
-                    move |In(_entity): In<Entity>,
-                    mut event: ResMut<KEvent>,
+                move |In(_entity): In<Entity>,
+                      mut event: ResMut<KEvent>,
                       mut query: Query<&mut ButtonState>| {
                     if let Ok(mut button) = query.get_mut(state_entity) {
                         match event.event_type {

--- a/src/widgets/button.rs
+++ b/src/widgets/button.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Bundle, Color, Commands, Component, Entity, In, Query},
+    prelude::*,
     window::CursorIcon,
 };
 use kayak_font::Alignment;
@@ -54,7 +54,8 @@ pub struct ButtonState {
 }
 
 pub fn button_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KButton, &KStyle, &mut ComputedStyles)>,
     state_query: Query<&ButtonState>,

--- a/src/widgets/clip.rs
+++ b/src/widgets/clip.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query};
+use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, Res};
 
 use crate::{
     children::KChildren,
@@ -40,7 +40,8 @@ impl Default for ClipBundle {
 }
 
 pub fn clip_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KChildren)>,
 ) -> bool {

--- a/src/widgets/element.rs
+++ b/src/widgets/element.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query};
+use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, Res};
 
 use crate::{
     children::KChildren,
@@ -41,7 +41,8 @@ impl Default for ElementBundle {
 }
 
 pub fn element_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KChildren)>,
 ) -> bool {

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -2,7 +2,6 @@ use bevy::prelude::{Bundle, Component, Entity, Handle, In, Query};
 
 use crate::{
     context::WidgetName,
-    prelude::KayakWidgetContext,
     styles::{ComputedStyles, KStyle, RenderCommand},
     widget::Widget,
 };
@@ -34,7 +33,7 @@ impl Default for KImageBundle {
 }
 
 pub fn image_render(
-    In((_widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KImage)>,
 ) -> bool {
     if let Ok((style, mut computed_styles, image)) = query.get_mut(entity) {

--- a/src/widgets/modal.rs
+++ b/src/widgets/modal.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Bundle, Color, Commands, Component, Entity, In, Query},
+    prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res},
     window::CursorIcon,
 };
 use kayak_ui_macros::rsx;
@@ -75,7 +75,8 @@ impl Default for ModalBundle {
 }
 
 pub fn render(
-    In((widget_context, modal_entity)): In<(KayakWidgetContext, Entity)>,
+    In(modal_entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &KChildren, &Modal, &mut ComputedStyles)>,
     mut transition_state_query: Query<&mut TransitionState>,

--- a/src/widgets/nine_patch.rs
+++ b/src/widgets/nine_patch.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Commands, Component, Entity, Handle, Image, In, Query};
+use bevy::prelude::{Bundle, Commands, Component, Entity, Handle, Image, In, Query, Res};
 
 use crate::{
     children::KChildren,
@@ -72,7 +72,8 @@ impl Default for NinePatchBundle {
 }
 
 pub fn nine_patch_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &mut ComputedStyles, &NinePatch, &KChildren)>,
 ) -> bool {

--- a/src/widgets/scroll/scroll_bar.rs
+++ b/src/widgets/scroll/scroll_bar.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query};
+use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res};
 use kayak_ui_macros::rsx;
 
 use crate::{
@@ -56,7 +56,8 @@ impl Default for ScrollBarBundle {
 }
 
 pub fn scroll_bar_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&ScrollBarProps, &KStyle, &mut ComputedStyles)>,
     context_query: Query<&ScrollContext>,

--- a/src/widgets/scroll/scroll_bar.rs
+++ b/src/widgets/scroll/scroll_bar.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res};
+use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res, ResMut};
 use kayak_ui_macros::rsx;
 
 use crate::{
@@ -9,7 +9,6 @@ use crate::{
     prelude::{KChildren, KayakWidgetContext},
     styles::{ComputedStyles, Corner, Edge, KPositionType, KStyle, RenderCommand, Units},
     widget::Widget,
-    widget_state::WidgetState,
     widgets::{BackgroundBundle, ClipBundle},
 };
 
@@ -204,12 +203,9 @@ pub fn scroll_bar_render(
 
                 // === Events === //
                 let on_event = OnEvent::new(
-                    move |In((mut event_dispatcher_context, _, mut event, _entity)): In<(
-                        EventDispatcherContext,
-                        WidgetState,
-                        KEvent,
-                        Entity,
-                    )>,
+                    move |In(_entity): In<Entity>,
+                          mut event_dispatcher_context: ResMut<EventDispatcherContext>,
+                          mut event: ResMut<KEvent>,
                           mut query: Query<&mut ScrollContext>| {
                         if let Ok(mut scroll_context) = query.get_mut(context_entity) {
                             match event.event_type {
@@ -296,8 +292,6 @@ pub fn scroll_bar_render(
                                 _ => {}
                             }
                         }
-
-                        (event_dispatcher_context, event)
                     },
                 );
 

--- a/src/widgets/scroll/scroll_box.rs
+++ b/src/widgets/scroll/scroll_box.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, ParamSet, Query};
+use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, ParamSet, Query, Res};
 
 use crate::{
     children::KChildren,
@@ -79,7 +79,8 @@ impl Default for ScrollBoxBundle {
 }
 
 pub fn scroll_box_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(
         &ScrollBoxProps,

--- a/src/widgets/scroll/scroll_box.rs
+++ b/src/widgets/scroll/scroll_box.rs
@@ -1,18 +1,16 @@
-use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, ParamSet, Query, Res};
+use bevy::prelude::{Bundle, Color, Commands, Component, Entity, In, ParamSet, Query, Res, ResMut};
 
 use crate::{
     children::KChildren,
     context::WidgetName,
     cursor::ScrollUnit,
     event::{EventType, KEvent},
-    event_dispatcher::EventDispatcherContext,
     layout::{GeometryChanged, LayoutEvent},
     on_event::OnEvent,
     on_layout::OnLayout,
     prelude::{constructor, rsx, KayakWidgetContext},
     styles::{ComputedStyles, KPositionType, KStyle, LayoutType, RenderCommand, Units},
     widget::Widget,
-    widget_state::WidgetState,
     widgets::{
         scroll::{
             scroll_bar::{ScrollBarBundle, ScrollBarProps},
@@ -183,12 +181,8 @@ pub fn scroll_box_render(
                 });
 
                 let event_handler = OnEvent::new(
-                    move |In((event_dispatcher_context, _, mut event, _entity)): In<(
-                        EventDispatcherContext,
-                        WidgetState,
-                        KEvent,
-                        Entity,
-                    )>,
+                    move |In(_entity): In<Entity>,
+                          mut event: ResMut<KEvent>,
                           mut query: Query<&mut ScrollContext>| {
                         if let Ok(mut scroll_context) = query.get_mut(context_entity) {
                             match event.event_type {
@@ -218,7 +212,6 @@ pub fn scroll_box_render(
                                 _ => {}
                             }
                         }
-                        (event_dispatcher_context, event)
                     },
                 );
 

--- a/src/widgets/scroll/scroll_content.rs
+++ b/src/widgets/scroll/scroll_content.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, With, Res};
+use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, Res, With};
 
 use crate::{
     children::KChildren,

--- a/src/widgets/scroll/scroll_content.rs
+++ b/src/widgets/scroll/scroll_content.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, With};
+use bevy::prelude::{Bundle, Commands, Component, Entity, In, Query, With, Res};
 
 use crate::{
     children::KChildren,
@@ -42,7 +42,8 @@ impl Default for ScrollContentBundle {
 }
 
 pub fn scroll_content_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<
         (&KStyle, &mut ComputedStyles, &KChildren, &mut OnLayout),

--- a/src/widgets/scroll/scroll_context.rs
+++ b/src/widgets/scroll/scroll_context.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{BuildChildren, Bundle, Commands, Component, Entity, In, Query, Vec2};
+use bevy::prelude::{BuildChildren, Bundle, Commands, Component, Entity, In, Query, Vec2, Res};
 
 use crate::{
     children::KChildren,
@@ -163,7 +163,8 @@ impl Default for ScrollContextProviderBundle {
 }
 
 pub fn scroll_context_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(
         &ScrollContextProvider,

--- a/src/widgets/scroll/scroll_context.rs
+++ b/src/widgets/scroll/scroll_context.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{BuildChildren, Bundle, Commands, Component, Entity, In, Query, Vec2, Res};
+use bevy::prelude::{BuildChildren, Bundle, Commands, Component, Entity, In, Query, Res, Vec2};
 
 use crate::{
     children::KChildren,

--- a/src/widgets/svg.rs
+++ b/src/widgets/svg.rs
@@ -1,6 +1,5 @@
 use crate::{
     context::WidgetName,
-    prelude::KayakWidgetContext,
     styles::{ComputedStyles, KStyle, RenderCommand},
     widget::Widget,
 };
@@ -34,7 +33,7 @@ impl Default for KSvgBundle {
 }
 
 pub fn svg_render(
-    In((_widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KSvg)>,
 ) -> bool {
     if let Ok((style, mut computed_styles, svg)) = query.get_mut(entity) {

--- a/src/widgets/text.rs
+++ b/src/widgets/text.rs
@@ -3,7 +3,6 @@ use kayak_font::Alignment;
 
 use crate::{
     context::WidgetName,
-    prelude::KayakWidgetContext,
     styles::{ComputedStyles, KCursorIcon, KStyle, RenderCommand, StyleProp},
     widget::Widget,
 };
@@ -74,7 +73,7 @@ impl Default for TextWidgetBundle {
 }
 
 pub fn text_render(
-    In((_widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
     mut query: Query<(&KStyle, &mut ComputedStyles, &TextProps)>,
 ) -> bool {
     if let Ok((styles, mut computed_styles, text)) = query.get_mut(entity) {

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -7,14 +7,12 @@ use kayak_ui_macros::{constructor, rsx};
 use crate::{
     context::WidgetName,
     event::{EventType, KEvent},
-    event_dispatcher::EventDispatcherContext,
     on_event::OnEvent,
     on_layout::OnLayout,
     prelude::{KChildren, KayakWidgetContext, OnChange},
     render::font::FontMapping,
     styles::{ComputedStyles, Edge, KPositionType, KStyle, RenderCommand, StyleProp, Units},
     widget::Widget,
-    widget_state::WidgetState,
     widgets::{
         text::{TextProps, TextWidgetBundle},
         BackgroundBundle, ClipBundle,
@@ -183,12 +181,8 @@ pub fn text_box_render(
             let cloned_on_change = on_change.clone();
 
             *on_event = OnEvent::new(
-                move |In((event_dispatcher_context, _, mut event, _entity)): In<(
-                    EventDispatcherContext,
-                    WidgetState,
-                    KEvent,
-                    Entity,
-                )>,
+                    move |In(_entity): In<Entity>,
+                    mut event: ResMut<KEvent>,
                       font_assets: Res<Assets<KayakFont>>,
                       font_mapping: Res<FontMapping>,
                       mut state_query: Query<&mut TextBoxState>| {
@@ -225,7 +219,7 @@ pub fn text_box_render(
                             if let Ok(mut state) = state_query.get_mut(state_entity) {
                                 let cloned_on_change = cloned_on_change.clone();
                                 if !state.focused {
-                                    return (event_dispatcher_context, event);
+                                    return;
                                 }
                                 let cursor_pos = state.cursor_position;
                                 if is_backspace(c) {
@@ -283,7 +277,6 @@ pub fn text_box_render(
                         }
                         _ => {}
                     }
-                    (event_dispatcher_context, event)
                 },
             );
 

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -181,8 +181,8 @@ pub fn text_box_render(
             let cloned_on_change = on_change.clone();
 
             *on_event = OnEvent::new(
-                    move |In(_entity): In<Entity>,
-                    mut event: ResMut<KEvent>,
+                move |In(_entity): In<Entity>,
+                      mut event: ResMut<KEvent>,
                       font_assets: Res<Assets<KayakFont>>,
                       font_mapping: Res<FontMapping>,
                       mut state_query: Query<&mut TextBoxState>| {

--- a/src/widgets/text_box.rs
+++ b/src/widgets/text_box.rs
@@ -99,7 +99,8 @@ impl Default for TextBoxBundle {
 }
 
 pub fn text_box_render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(
         &KStyle,

--- a/src/widgets/texture_atlas.rs
+++ b/src/widgets/texture_atlas.rs
@@ -2,7 +2,6 @@ use bevy::prelude::{Bundle, Component, Entity, Handle, Image, In, Query, Vec2};
 
 use crate::{
     context::WidgetName,
-    prelude::KayakWidgetContext,
     styles::{ComputedStyles, KStyle, RenderCommand},
     widget::Widget,
 };
@@ -55,7 +54,7 @@ impl Default for TextureAtlasBundle {
 }
 
 pub fn texture_atlas_render(
-    In((_widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
     mut query: Query<(&KStyle, &mut ComputedStyles, &TextureAtlasProps)>,
 ) -> bool {
     if let Ok((styles, mut computed_styles, texture_atlas)) = query.get_mut(entity) {

--- a/src/widgets/transition.rs
+++ b/src/widgets/transition.rs
@@ -296,7 +296,8 @@ impl Default for TransitionBundle {
 }
 
 pub fn render(
-    In((widget_context, entity)): In<(KayakWidgetContext, Entity)>,
+    In(entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&TransitionProps, &KChildren)>,
     mut transition_state_query: Query<&mut TransitionState>,

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Vec2, Res},
+    prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Vec2, Res, ResMut},
     window::CursorIcon,
 };
 use kayak_ui_macros::rsx;
@@ -16,7 +16,6 @@ use crate::{
         Units,
     },
     widget::Widget,
-    widget_state::WidgetState,
     Focusable,
 };
 
@@ -131,12 +130,8 @@ pub fn window_render(
             let parent_id = Some(window_entity);
 
             let focus_event = OnEvent::new(
-                move |In((event_dispatcher_context, _, mut event, _entity)): In<(
-                    EventDispatcherContext,
-                    WidgetState,
-                    KEvent,
-                    Entity,
-                )>,
+                    move |In(_entity): In<Entity>,
+                    mut event: ResMut<KEvent>,
                       mut query: Query<&mut KWindowState>,
                       mut context_query: Query<&mut WindowContext>| {
                     if let Ok(mut window) = query.get_mut(state_entity) {
@@ -160,7 +155,6 @@ pub fn window_render(
                             _ => {}
                         }
                     }
-                    (event_dispatcher_context, event)
                 },
             );
 
@@ -225,12 +219,9 @@ pub fn window_render(
                             commands
                                 .entity(title_bar_entity)
                                 .insert(OnEvent::new(
-                                    move |In((mut event_dispatcher_context, _, mut event, entity)): In<(
-                                        EventDispatcherContext,
-                                        WidgetState,
-                                        KEvent,
-                                        Entity,
-                                    )>,
+                                    move |In(entity): In<Entity>,
+                                    mut event_dispatcher_context: ResMut<EventDispatcherContext>,
+                                    mut event: ResMut<KEvent>,
                                         mut query: Query<&mut KWindowState>| {
                                         if let Ok(mut window) = query.get_mut(state_entity) {
                                             event.prevent_default();
@@ -259,7 +250,6 @@ pub fn window_render(
                                                 _ => {}
                                             }
                                         }
-                                        (event_dispatcher_context, event)
                                     },
                                 ));
                         }

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Vec2, Res, ResMut},
+    prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Res, ResMut, Vec2},
     window::CursorIcon,
 };
 use kayak_ui_macros::rsx;
@@ -130,8 +130,8 @@ pub fn window_render(
             let parent_id = Some(window_entity);
 
             let focus_event = OnEvent::new(
-                    move |In(_entity): In<Entity>,
-                    mut event: ResMut<KEvent>,
+                move |In(_entity): In<Entity>,
+                      mut event: ResMut<KEvent>,
                       mut query: Query<&mut KWindowState>,
                       mut context_query: Query<&mut WindowContext>| {
                     if let Ok(mut window) = query.get_mut(state_entity) {

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Vec2},
+    prelude::{Bundle, Color, Commands, Component, Entity, In, Query, Vec2, Res},
     window::CursorIcon,
 };
 use kayak_ui_macros::rsx;
@@ -79,7 +79,8 @@ impl Default for WindowBundle {
 }
 
 pub fn window_render(
-    In((widget_context, window_entity)): In<(KayakWidgetContext, Entity)>,
+    In(window_entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     mut query: Query<(&KStyle, &mut ComputedStyles, &KChildren, &KWindow)>,
     state_query: Query<&KWindowState>,

--- a/src/widgets/window_context_provider.rs
+++ b/src/widgets/window_context_provider.rs
@@ -66,7 +66,8 @@ impl Default for WindowContextProviderBundle {
 }
 
 pub fn window_context_render(
-    In((widget_context, window_context_entity)): In<(KayakWidgetContext, Entity)>,
+    In(window_context_entity): In<Entity>,
+    widget_context: Res<KayakWidgetContext>,
     mut commands: Commands,
     children_query: Query<&KChildren>,
 ) -> bool {


### PR DESCRIPTION
This PR refactors a lot of widget systems and event systems to use resources instead of the weird `In` syntax. This has the advantage of cleaning up quite a bit of code.