### PR TITLE
v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kayak_ui"
 description = "A UI library built using the bevy game engine!"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 resolver = "2"
 authors = ["John Mitchell"]

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -20,17 +20,23 @@ fn startup(
     let parent_id = None;
     rsx! {
         <KayakAppBundle>
-            <KSvgBundle
-                svg={KSvg(svg)}
+            <ElementBundle
                 styles={KStyle {
                     position_type: StyleProp::Value(KPositionType::SelfDirected),
-                    left: StyleProp::Value(Units::Pixels(10.0)),
-                    top: StyleProp::Value(Units::Pixels(10.0)),
-                    width: StyleProp::Value(Units::Pixels(800.0)),
-                    height: StyleProp::Value(Units::Pixels(800.0)),
+                    left: StyleProp::Value(Units::Pixels(-34.545261 * 7.6)),
+                    top: StyleProp::Value(Units::Pixels(10.0 - 95.557219 * 7.6)),
                     ..Default::default()
                 }}
-            />
+            >
+                <KSvgBundle
+                    svg={KSvg(svg)}
+                    styles={KStyle {
+                        width: StyleProp::Value(Units::Pixels(800.0)),
+                        height: StyleProp::Value(Units::Pixels(800.0)),
+                        ..Default::default()
+                    }}
+                />
+            </ElementBundle>
         </KayakAppBundle>
     };
 

--- a/examples/tabs/tabs.rs
+++ b/examples/tabs/tabs.rs
@@ -75,10 +75,10 @@ fn startup(
                             ..Default::default()
                         }}
                     >
-                        <TabBundle tab={Tab { index: 0 }}>
+                        <TabBundle key={"tab1"} tab={Tab { index: 0 }}>
                             <TextWidgetBundle text={TextProps { content: "Tab 1 Content".into(), size: 14.0, line_height: Some(14.0), ..Default::default() }} />
                         </TabBundle>
-                        <TabBundle tab={Tab { index: 1 }}>
+                        <TabBundle key={"tab2"} tab={Tab { index: 1 }}>
                             <TextWidgetBundle text={TextProps { content: "Tab 2 Content".into(), size: 14.0, line_height: Some(14.0), ..Default::default() }} />
                         </TabBundle>
                     </ElementBundle>

--- a/src/children.rs
+++ b/src/children.rs
@@ -63,6 +63,7 @@ impl KChildren {
         for child in self.inner.iter() {
             if let Some(parent_id) = parent_id {
                 if let Some(mut entity_commands) = commands.get_entity(*child) {
+                    entity_commands.remove::<Parent>();
                     entity_commands.set_parent(parent_id);
                 }
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -227,10 +227,8 @@ impl KayakRootContext {
         parent_id: Option<Entity>,
         context_entity: Entity,
     ) {
-        if let Some(parent_id) = parent_id {
-            self.context_entities
-                .add_context_entity::<T>(parent_id, context_entity);
-        }
+        self.context_entities
+            .add_context_entity::<T>(parent_id, context_entity);
     }
 
     /// Returns a new/existing widget entity.

--- a/src/context.rs
+++ b/src/context.rs
@@ -811,11 +811,11 @@ fn update_widgets(
                                             if widget_name != prev_widget_name {
                                                 // It doesn't matter we always need to remove state
                                                 remove_state.push(changed_entity.0);
-                                                if let Some(_) = tree.parent(*changed_entity) {
+                                                if tree.parent(*changed_entity).is_some() {
                                                     for child in
                                                         tree.down_iter_at(*changed_entity, false)
                                                     {
-                                                        info!(
+                                                        trace!(
                                                             "Removing AvsB children {}::{}",
                                                             entity_ref
                                                                 .get::<WidgetName>()
@@ -827,25 +827,25 @@ fn update_widgets(
                                                         if let Ok(order_tree) =
                                                             order_tree.try_read()
                                                         {
-                                                            if let Some(order_tree_parent) = order_tree
-                                                                .parent(*changed_entity) {
+                                                            if let Some(order_tree_parent) =
+                                                                order_tree.parent(*changed_entity)
+                                                            {
                                                                 'back_up: for sibling in order_tree
                                                                     .child_iter(order_tree_parent)
                                                                 {
-                                                                    dbg!(sibling, changed_entity);
                                                                     if sibling == *changed_entity {
                                                                         continue 'back_up;
                                                                     }
-                                                                    for child in
-                                                                        tree.down_iter_at(sibling, true)
-                                                                    {   
+                                                                    for child in tree
+                                                                        .down_iter_at(sibling, true)
+                                                                    {
                                                                         // Ignore self again.
-                                                                        dbg!(child);
                                                                         if child == *parent {
                                                                             continue;
                                                                         }
                                                                         if let Some(entity_ref) =
-                                                                            world.get_entity(child.0)
+                                                                            world
+                                                                                .get_entity(child.0)
                                                                         {
                                                                             if let Some(children) =
                                                                                 entity_ref
@@ -857,7 +857,7 @@ fn update_widgets(
                                                                                             .0,
                                                                                     )
                                                                                 {
-                                                                                    info!("Caught an entity that was marked as deleted but wasn't! {:?} in {:?}", changed_entity.0, child.0);
+                                                                                    trace!("Caught an entity that was marked as deleted but wasn't! {:?} in {:?}", changed_entity.0, child.0);
                                                                                     // Don't despawn changed entity because it exists as a child passed via props
                                                                                     should_delete =
                                                                                         false;
@@ -885,9 +885,10 @@ fn update_widgets(
                                 }
                             }
 
-                            for entity in remove_state.iter() { 
+                            for entity in remove_state.iter() {
                                 if let Some(state_entity) = widget_state.remove(*entity) {
-                                    if let Some(mut entity_mut) = world.get_entity_mut(state_entity) {
+                                    if let Some(mut entity_mut) = world.get_entity_mut(state_entity)
+                                    {
                                         entity_mut.remove_parent();
                                         entity_mut.despawn_recursive();
                                     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -815,7 +815,7 @@ fn update_widgets(
                                                     for child in
                                                         tree.down_iter_at(*changed_entity, false)
                                                     {
-                                                        trace!(
+                                                        info!(
                                                             "Removing AvsB children {}::{}",
                                                             entity_ref
                                                                 .get::<WidgetName>()
@@ -827,34 +827,42 @@ fn update_widgets(
                                                         if let Ok(order_tree) =
                                                             order_tree.try_read()
                                                         {
-                                                            'back_up: for sibling in order_tree
-                                                                .child_iter(
-                                                                    order_tree
-                                                                        .parent(*changed_entity)
-                                                                        .unwrap(),
-                                                                )
-                                                            {
-                                                                for child in
-                                                                    tree.down_iter_at(sibling, true)
+                                                            if let Some(order_tree_parent) = order_tree
+                                                                .parent(*changed_entity) {
+                                                                'back_up: for sibling in order_tree
+                                                                    .child_iter(order_tree_parent)
                                                                 {
-                                                                    if let Some(entity_ref) =
-                                                                        world.get_entity(child.0)
-                                                                    {
-                                                                        if let Some(children) =
-                                                                            entity_ref
-                                                                                .get::<KChildren>()
+                                                                    dbg!(sibling, changed_entity);
+                                                                    if sibling == *changed_entity {
+                                                                        continue 'back_up;
+                                                                    }
+                                                                    for child in
+                                                                        tree.down_iter_at(sibling, true)
+                                                                    {   
+                                                                        // Ignore self again.
+                                                                        dbg!(child);
+                                                                        if child == *parent {
+                                                                            continue;
+                                                                        }
+                                                                        if let Some(entity_ref) =
+                                                                            world.get_entity(child.0)
                                                                         {
-                                                                            if children
-                                                                                .contains_entity(
-                                                                                    changed_entity
-                                                                                        .0,
-                                                                                )
+                                                                            if let Some(children) =
+                                                                                entity_ref
+                                                                                    .get::<KChildren>()
                                                                             {
-                                                                                trace!("Caught an entity that was marked as deleted but wasn't! {:?}", changed_entity.0);
-                                                                                // Don't despawn changed entity because it exists as a child passed via props
-                                                                                should_delete =
-                                                                                    false;
-                                                                                break 'back_up;
+                                                                                if children
+                                                                                    .contains_entity(
+                                                                                        changed_entity
+                                                                                            .0,
+                                                                                    )
+                                                                                {
+                                                                                    info!("Caught an entity that was marked as deleted but wasn't! {:?} in {:?}", changed_entity.0, child.0);
+                                                                                    // Don't despawn changed entity because it exists as a child passed via props
+                                                                                    should_delete =
+                                                                                        false;
+                                                                                    break 'back_up;
+                                                                                }
                                                                             }
                                                                         }
                                                                     }
@@ -1005,7 +1013,7 @@ fn update_widgets(
                                     entity_mut.get::<WidgetName>(),
                                     parent.index(),
                                 );
-                                entity_mut.remove_parent();
+                                entity_mut.remove::<Parent>();
                                 entity_mut.remove::<bevy::prelude::Children>();
                                 entity_mut.despawn();
 

--- a/src/context_entities.rs
+++ b/src/context_entities.rs
@@ -30,7 +30,10 @@ impl ContextEntities {
         inner.insert(T::default().type_id(), context_entity);
     }
 
-    pub fn get_context_entity<T: Default + 'static>(&self, parent_id: Option<Entity>) -> Option<Entity> {
+    pub fn get_context_entity<T: Default + 'static>(
+        &self,
+        parent_id: Option<Entity>,
+    ) -> Option<Entity> {
         if !self.ce.contains_key(&parent_id) {
             return None;
         }

--- a/src/context_entities.rs
+++ b/src/context_entities.rs
@@ -8,7 +8,7 @@ use dashmap::DashMap;
 
 #[derive(Debug, Clone)]
 pub struct ContextEntities {
-    ce: Arc<DashMap<Entity, DashMap<TypeId, Entity>>>,
+    ce: Arc<DashMap<Option<Entity>, DashMap<TypeId, Entity>>>,
 }
 
 impl ContextEntities {
@@ -20,7 +20,7 @@ impl ContextEntities {
 
     pub fn add_context_entity<T: Default + 'static>(
         &self,
-        parent_id: Entity,
+        parent_id: Option<Entity>,
         context_entity: Entity,
     ) {
         if !self.ce.contains_key(&parent_id) {
@@ -30,7 +30,7 @@ impl ContextEntities {
         inner.insert(T::default().type_id(), context_entity);
     }
 
-    pub fn get_context_entity<T: Default + 'static>(&self, parent_id: Entity) -> Option<Entity> {
+    pub fn get_context_entity<T: Default + 'static>(&self, parent_id: Option<Entity>) -> Option<Entity> {
         if !self.ce.contains_key(&parent_id) {
             return None;
         }

--- a/src/event_dispatcher.rs
+++ b/src/event_dispatcher.rs
@@ -425,9 +425,8 @@ impl EventDispatcher {
                             let mut stack_children = Vec::new();
                             for child in children {
                                 let child_z = world
-                                    .entity(child.0)
-                                    .get::<Node>()
-                                    .map(|node| node.z)
+                                    .get_entity(child.0)
+                                    .map(|e| e.get::<Node>().map(|node| node.z).unwrap_or(0.0))
                                     .unwrap_or(0.0);
                                 stack_children.push((child_z, (*child, depth + 1)));
                             }
@@ -862,7 +861,7 @@ impl EventDispatcher {
     }
 }
 
-#[derive(Resource)]
+#[derive(Resource, Default)]
 pub struct EventDispatcherContext {
     cursor_capture: Option<WrappedIndex>,
 }

--- a/src/render/ui_pass.rs
+++ b/src/render/ui_pass.rs
@@ -4,7 +4,7 @@ use bevy::ecs::prelude::*;
 use bevy::prelude::{Color, Image};
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{
-    BatchedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem, DrawFunctions,
+    BatchedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, DrawFunctions, PhaseItem,
 };
 use bevy::render::render_resource::{CachedRenderPipelineId, RenderPassColorAttachment};
 use bevy::render::{
@@ -233,8 +233,12 @@ impl Node for MainPassUINode {
 
                     let mut tracked_pass =
                         render_context.begin_tracked_render_pass(pass_descriptor);
-            
-                    for item in transparent_opacity_phase.items.iter().filter(|i| i.opacity_layer == layer_id) {
+
+                    for item in transparent_opacity_phase
+                        .items
+                        .iter()
+                        .filter(|i| i.opacity_layer == layer_id)
+                    {
                         let draw_function = draw_functions.get_mut(item.draw_function()).unwrap();
                         draw_function.draw(world, &mut tracked_pass, view_entity, item);
                     }

--- a/src/render/unified/pipeline.rs
+++ b/src/render/unified/pipeline.rs
@@ -950,12 +950,7 @@ pub fn queue_quads_inner(
                     position: final_position.into(),
                     color,
                     uv: [0.0; 4],
-                    pos_size: [
-                        0.0,
-                        0.0,
-                        sprite_rect.size().x,
-                        sprite_rect.size().y,
-                    ],
+                    pos_size: [0.0, 0.0, sprite_rect.size().x, sprite_rect.size().y],
                 });
             }
             *index += indices.len() as u32;

--- a/src/render/unified/pipeline.rs
+++ b/src/render/unified/pipeline.rs
@@ -951,8 +951,8 @@ pub fn queue_quads_inner(
                     color,
                     uv: [0.0; 4],
                     pos_size: [
-                        sprite_rect.min.x,
-                        sprite_rect.min.y,
+                        0.0,
+                        0.0,
                         sprite_rect.size().x,
                         sprite_rect.size().y,
                     ],

--- a/src/widget_context.rs
+++ b/src/widget_context.rs
@@ -103,10 +103,7 @@ impl KayakWidgetContext {
             }
 
             // Finally check root AKA no parent.
-            if let Some(entity) = self
-                .context_entities
-                .get_context_entity::<T>(None)
-            {
+            if let Some(entity) = self.context_entities.get_context_entity::<T>(None) {
                 return Some(entity);
             }
         }
@@ -200,10 +197,10 @@ impl KayakWidgetContext {
     ///     widget_context.add_widget(None, root_entity);
     /// }
     ///```
-    pub fn spawn_widget<'a>(
+    pub fn spawn_widget(
         &self,
         commands: &mut Commands,
-        key: Option<&'a str>,
+        key: Option<&str>,
         parent_id: Option<Entity>,
     ) -> Entity {
         let mut entity = None;

--- a/src/widget_context.rs
+++ b/src/widget_context.rs
@@ -72,10 +72,8 @@ impl KayakWidgetContext {
         parent_id: Option<Entity>,
         context_entity: Entity,
     ) {
-        if let Some(parent_id) = parent_id {
-            self.context_entities
-                .add_context_entity::<T>(parent_id, context_entity);
-        }
+        self.context_entities
+            .add_context_entity::<T>(parent_id, context_entity);
     }
 
     /// Finds the closest matching context entity by traversing up the tree.
@@ -86,7 +84,7 @@ impl KayakWidgetContext {
         // Check self first..
         if let Some(entity) = self
             .context_entities
-            .get_context_entity::<T>(current_entity)
+            .get_context_entity::<T>(Some(current_entity))
         {
             return Some(entity);
         }
@@ -97,11 +95,19 @@ impl KayakWidgetContext {
             while parent.is_some() {
                 if let Some(entity) = self
                     .context_entities
-                    .get_context_entity::<T>(parent.unwrap().0)
+                    .get_context_entity::<T>(Some(parent.unwrap().0))
                 {
                     return Some(entity);
                 }
                 parent = tree.get_parent(parent.unwrap());
+            }
+
+            // Finally check root AKA no parent.
+            if let Some(entity) = self
+                .context_entities
+                .get_context_entity::<T>(None)
+            {
+                return Some(entity);
             }
         }
 

--- a/src/widget_context.rs
+++ b/src/widget_context.rs
@@ -194,10 +194,10 @@ impl KayakWidgetContext {
     ///     widget_context.add_widget(None, root_entity);
     /// }
     ///```
-    pub fn spawn_widget(
+    pub fn spawn_widget<'a>(
         &self,
         commands: &mut Commands,
-        key: Option<&'static str>,
+        key: Option<&'a str>,
         parent_id: Option<Entity>,
     ) -> Entity {
         let mut entity = None;
@@ -358,6 +358,11 @@ impl KayakWidgetContext {
         println!("Old:");
         if let Ok(tree) = self.old_tree.read() {
             tree.dump_at(WrappedIndex(entity));
+        }
+
+        println!("Order tree:");
+        if let Ok(order_tree) = self.order_tree.read() {
+            order_tree.dump_all_at(None, entity);
         }
     }
 


### PR DESCRIPTION
Release prep for 0.4.1 bugfix.

Fixes:
- Tree issues when removing widgets.
- Removed `&'static str` requirement for widget keys in favor of `&str`.
- Fixed bug where cloning `OnEvent` system components caused crashes. 
- Fixed conditional widget issues with bad removals.
- Fixed root context not working
- Fixed opacity layer issue
- Fixed SVG example not working correctly.
- Fixed A vs B widget not being swapped properly in the tree. 