### PR TITLE
Adding more click functionality

### DIFF
--- a/examples/avsb.rs
+++ b/examples/avsb.rs
@@ -60,7 +60,7 @@ fn current_count_render(
                         move |In(_entity): In<Entity>,
                         mut event: ResMut<KEvent>,
                             mut query: Query<&mut CurrentCountState>| {
-                            if let EventType::Click(..) = event.event_type {
+                            if let EventType::LeftClick(..) = event.event_type {
                                 event.prevent_default();
                                 event.stop_propagation();
                                 if let Ok(mut current_count) = query.get_mut(state_entity) {

--- a/examples/bevy_scene.rs
+++ b/examples/bevy_scene.rs
@@ -186,7 +186,7 @@ fn startup(
         move |In(_entity): In<Entity>,
               event: Res<KEvent>,
               mut active_color: ResMut<ActiveColor>| {
-            if let EventType::Click(..) = event.event_type {
+            if let EventType::LeftClick(..) = event.event_type {
                 active_color.index = (active_color.index + 1) % COLORS.len();
             }
         },

--- a/examples/conditional_widget.rs
+++ b/examples/conditional_widget.rs
@@ -54,7 +54,7 @@ fn my_widget_render(
                             mut query: Query<&mut MyWidgetState>| {
                             event.prevent_default();
                             event.stop_propagation();
-                            if let EventType::Click(..) = event.event_type {
+                            if let EventType::LeftClick(..) = event.event_type {
                                 if let Ok(mut state) = query.get_mut(state_entity) {
                                     state.show_window = true;
                                 }
@@ -79,7 +79,7 @@ fn my_widget_render(
                                     move |In(_entity): In<Entity>,
                                     mut event: ResMut<KEvent>,
                                         mut query: Query<&mut MyWidgetState>| {
-                                        if let EventType::Click(..) = event.event_type {
+                                        if let EventType::LeftClick(..) = event.event_type {
                                             event.prevent_default();
                                             event.stop_propagation();
                                             if let Ok(mut state) = query.get_mut(state_entity) {

--- a/examples/context.rs
+++ b/examples/context.rs
@@ -107,7 +107,7 @@ fn update_theme_button(
                             query: Query<&ThemeButton>,
                             mut context_query: Query<&mut Theme>,
                             | {
-                                if let EventType::Click(..) = event.event_type {
+                                if let EventType::LeftClick(..) = event.event_type {
                                     if let Ok(button) = query.get(theme_button_entity) {
                                         if let Ok(mut context_theme) = context_query.get_mut(theme_context_entity) {
                                             *context_theme = button.theme.clone();

--- a/examples/main_menu.rs
+++ b/examples/main_menu.rs
@@ -149,7 +149,7 @@ fn startup(
 
     let handle_click_close = OnEvent::new(
         move |In(_entity): In<Entity>, event: ResMut<KEvent>, mut exit: EventWriter<AppExit>| {
-            if let EventType::Click(..) = event.event_type {
+            if let EventType::LeftClick(..) = event.event_type {
                 exit.send(AppExit);
             }
         },

--- a/examples/modal.rs
+++ b/examples/modal.rs
@@ -66,7 +66,7 @@ fn my_widget_render(
                             mut query: Query<&mut MyWidgetState>| {
                             event.prevent_default();
                             event.stop_propagation();
-                            if let EventType::Click(..) = event.event_type {
+                            if let EventType::LeftClick(..) = event.event_type {
                                 if let Ok(mut state) = query.get_mut(state_entity) {
                                     state.show_modal = true;
                                 }
@@ -107,7 +107,7 @@ fn my_widget_render(
                             move |In(_entity): In<Entity>,
                             mut event: ResMut<KEvent>,
                                 mut query: Query<&mut MyWidgetState>| {
-                                if let EventType::Click(..) = event.event_type {
+                                if let EventType::LeftClick(..) = event.event_type {
                                     event.prevent_default();
                                     event.stop_propagation();
                                     if let Ok(mut state) = query.get_mut(state_entity) {

--- a/examples/simple_state.rs
+++ b/examples/simple_state.rs
@@ -65,7 +65,7 @@ fn current_count_render(
                         move |In(_entity): In<Entity>,
                         mut event: ResMut<KEvent>,
                             mut query: Query<&mut CurrentCountState>| {
-                            if let EventType::Click(..) = event.event_type {
+                            if let EventType::LeftClick(..) = event.event_type {
                                 event.prevent_default();
                                 event.stop_propagation();
                                 if let Ok(mut current_count) = query.get_mut(state_entity) {

--- a/examples/tabs/tab_button.rs
+++ b/examples/tabs/tab_button.rs
@@ -58,7 +58,7 @@ pub fn tab_button_render(
                 move |In(_entity): In<Entity>,
                       event: Res<KEvent>,
                       mut query: Query<&mut TabContext>| {
-                    if let EventType::Click(..) = event.event_type {
+                    if let EventType::LeftClick(..) = event.event_type {
                         if let Ok(mut tab_context) = query.get_mut(context_entity) {
                             tab_context.current_index = button_index;
                         }

--- a/examples/todo/input.rs
+++ b/examples/todo/input.rs
@@ -50,7 +50,7 @@ pub fn render_todo_input(
 
     let handle_click = OnEvent::new(
         move |In(_entity): In<Entity>, event: Res<KEvent>, mut todo_list: ResMut<TodoList>| {
-            if let EventType::Click(..) = event.event_type {
+            if let EventType::LeftClick(..) = event.event_type {
                 if !todo_list.new_item.is_empty() {
                     let value = todo_list.new_item.clone();
                     todo_list.items.push(value);

--- a/examples/todo/items.rs
+++ b/examples/todo/items.rs
@@ -51,7 +51,7 @@ pub fn render_todo_items(
                     move |In(_entity): In<Entity>,
                           event: Res<KEvent>,
                         mut todo_list: ResMut<TodoList>,| {
-                        if let EventType::Click(..) = event.event_type {
+                        if let EventType::LeftClick(..) = event.event_type {
                             todo_list.items.remove(index);
                         }
                     },

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{Entity, Resource, World};
+use bevy::{prelude::{Entity, Resource, World}, window::Cursor};
 
 use crate::{
     cursor::{CursorEvent, ScrollEvent},
@@ -73,9 +73,11 @@ impl KEvent {
             self.event_type,
             EventType::LeftClick(..)
                 | EventType::RightClick(..)
+                | EventType::MiddleClick(..)
                 | EventType::MouseIn(..)
                 | EventType::MouseLeftDown(..)
                 | EventType::MouseRightDown(..)
+                | EventType::MouseMiddleDown(..)
                 | EventType::Scroll(..)
                 | EventType::Focus
                 | EventType::Hover(..)
@@ -116,6 +118,8 @@ pub enum EventType {
     LeftClick(CursorEvent),
     /// An event that occurs when the user right clicks a widget
     RightClick(CursorEvent),
+    /// An event that occurs when the user middle clicks a widget
+    MiddleClick(CursorEvent),
     /// An event that occurs when the user hovers the cursor over a widget
     Hover(CursorEvent),
     /// An event that occurs when the user moves the cursor into a widget
@@ -130,6 +134,10 @@ pub enum EventType {
     MouseRightDown(CursorEvent),
     /// An event that occurs when the user releases right mouse button over a widget
     MouseRightUp(CursorEvent),
+    /// An event that occurs when the user releases middle mouse button over a widget
+    MouseMiddleDown(CursorEvent),
+    /// An event that occurs when the user releases middle mouse button over a widget
+    MouseMiddleUp(CursorEvent),
     /// An event that occurs when the user scrolls over a widget
     Scroll(ScrollEvent),
     /// An event that occurs when a widget receives focus
@@ -182,10 +190,13 @@ impl EventType {
             Self::Hover(..) => true,
             Self::LeftClick(..) => true,
             Self::RightClick(..) => true,
+            Self::MiddleClick(..) => true,
             Self::MouseLeftDown(..) => true,
             Self::MouseLeftUp(..) => true,
             Self::MouseRightDown(..) => true,
             Self::MouseRightUp(..) => true,
+            Self::MouseMiddleDown(..) => true,
+            Self::MouseMiddleUp(..) => true,
             Self::Scroll(..) => true,
             Self::CharInput { .. } => true,
             Self::KeyUp(..) => true,
@@ -205,10 +216,13 @@ impl EventType {
             Self::Hover(..) => EventCategory::Mouse,
             Self::LeftClick(..) => EventCategory::Mouse,
             Self::RightClick(..) => EventCategory::Mouse,
+            Self::MiddleClick(..) => EventCategory::Mouse,
             Self::MouseLeftDown(..) => EventCategory::Mouse,
             Self::MouseLeftUp(..) => EventCategory::Mouse,
             Self::MouseRightDown(..) => EventCategory::Mouse,
             Self::MouseRightUp(..) => EventCategory::Mouse,
+            Self::MouseMiddleDown(..) => EventCategory::Mouse,
+            Self::MouseMiddleUp(..) => EventCategory::Mouse,
             Self::MouseIn(..) => EventCategory::Mouse,
             Self::MouseOut(..) => EventCategory::Mouse,
             Self::Scroll(..) => EventCategory::Mouse,

--- a/src/event.rs
+++ b/src/event.rs
@@ -38,7 +38,7 @@ impl Default for KEvent {
         Self {
             target: Entity::from_raw(0),
             current_target: Entity::from_raw(0),
-            event_type: EventType::Click(CursorEvent::default()),
+            event_type: EventType::LeftClick(CursorEvent::default()),
             should_propagate: true,
             default_prevented: false,
             on_change_systems: Vec::new(),
@@ -71,9 +71,11 @@ impl KEvent {
     pub fn stop_propagation(&mut self) {
         if matches!(
             self.event_type,
-            EventType::Click(..)
+            EventType::LeftClick(..)
+                | EventType::RightClick(..)
                 | EventType::MouseIn(..)
-                | EventType::MouseDown(..)
+                | EventType::MouseLeftDown(..)
+                | EventType::MouseRightDown(..)
                 | EventType::Scroll(..)
                 | EventType::Focus
                 | EventType::Hover(..)
@@ -110,18 +112,24 @@ impl KEvent {
 /// with a custom wrapper.
 #[derive(Debug, Clone, Copy)]
 pub enum EventType {
-    /// An event that occurs when the user clicks a widget
-    Click(CursorEvent),
+    /// An event that occurs when the user left clicks a widget
+    LeftClick(CursorEvent),
+    /// An event that occurs when the user right clicks a widget
+    RightClick(CursorEvent),
     /// An event that occurs when the user hovers the cursor over a widget
     Hover(CursorEvent),
     /// An event that occurs when the user moves the cursor into a widget
     MouseIn(CursorEvent),
     /// An event that occurs when the user moves the cursor out of a widget
     MouseOut(CursorEvent),
-    /// An event that occurs when the user presses down on the cursor over a widget
-    MouseDown(CursorEvent),
-    /// An event that occurs when the user releases the cursor over a widget
-    MouseUp(CursorEvent),
+    /// An event that occurs when the user presses left mouse button over a widget
+    MouseLeftDown(CursorEvent),
+    /// An event that occurs when the user releases left mouse button over a widget
+    MouseLeftUp(CursorEvent),
+    /// An event that occurs when the user presses right mouse button over a widget
+    MouseRightDown(CursorEvent),
+    /// An event that occurs when the user releases right mouse button over a widget
+    MouseRightUp(CursorEvent),
     /// An event that occurs when the user scrolls over a widget
     Scroll(ScrollEvent),
     /// An event that occurs when a widget receives focus
@@ -172,9 +180,12 @@ impl EventType {
         match self {
             // Propagates
             Self::Hover(..) => true,
-            Self::Click(..) => true,
-            Self::MouseDown(..) => true,
-            Self::MouseUp(..) => true,
+            Self::LeftClick(..) => true,
+            Self::RightClick(..) => true,
+            Self::MouseLeftDown(..) => true,
+            Self::MouseLeftUp(..) => true,
+            Self::MouseRightDown(..) => true,
+            Self::MouseRightUp(..) => true,
             Self::Scroll(..) => true,
             Self::CharInput { .. } => true,
             Self::KeyUp(..) => true,
@@ -192,9 +203,12 @@ impl EventType {
         match self {
             // Mouse
             Self::Hover(..) => EventCategory::Mouse,
-            Self::Click(..) => EventCategory::Mouse,
-            Self::MouseDown(..) => EventCategory::Mouse,
-            Self::MouseUp(..) => EventCategory::Mouse,
+            Self::LeftClick(..) => EventCategory::Mouse,
+            Self::RightClick(..) => EventCategory::Mouse,
+            Self::MouseLeftDown(..) => EventCategory::Mouse,
+            Self::MouseLeftUp(..) => EventCategory::Mouse,
+            Self::MouseRightDown(..) => EventCategory::Mouse,
+            Self::MouseRightUp(..) => EventCategory::Mouse,
             Self::MouseIn(..) => EventCategory::Mouse,
             Self::MouseOut(..) => EventCategory::Mouse,
             Self::Scroll(..) => EventCategory::Mouse,

--- a/src/event_dispatcher.rs
+++ b/src/event_dispatcher.rs
@@ -45,8 +45,10 @@ impl Default for EventState {
 
 #[derive(Component, Debug, Clone, Default)]
 pub struct EventDispatcher {
-    is_mouse_pressed: bool,
-    next_mouse_pressed: bool,
+    is_left_mouse_pressed: bool,
+    is_right_mouse_pressed: bool,
+    next_left_mouse_pressed: bool,
+    next_right_mouse_pressed: bool,
     current_mouse_position: (f32, f32),
     next_mouse_position: (f32, f32),
     previous_events: EventMap,
@@ -63,8 +65,10 @@ impl EventDispatcher {
     pub(crate) fn new() -> Self {
         Self {
             // last_clicked: Binding::new(WrappedIndex(Entity::from_raw(0))),
-            is_mouse_pressed: Default::default(),
-            next_mouse_pressed: Default::default(),
+            is_left_mouse_pressed: Default::default(),
+            is_right_mouse_pressed: Default::default(),
+            next_left_mouse_pressed: Default::default(),
+            next_right_mouse_pressed: Default::default(),
             current_mouse_position: Default::default(),
             next_mouse_position: Default::default(),
             previous_events: Default::default(),
@@ -77,10 +81,16 @@ impl EventDispatcher {
         }
     }
 
-    /// Returns whether the mouse is currently pressed or not
+    /// Returns whether the left mouse is currently pressed or not
     #[allow(dead_code)]
-    pub fn is_mouse_pressed(&self) -> bool {
-        self.is_mouse_pressed
+    pub fn is_left_mouse_pressed(&self) -> bool {
+        self.is_left_mouse_pressed
+    }
+
+    /// Returns whether the right mouse is currently pressed or not
+    #[allow(dead_code)]
+    pub fn is_right_mouse_pressed(&self) -> bool {
+        self.is_right_mouse_pressed
     }
 
     /// Gets the current mouse position (since last mouse event)
@@ -277,12 +287,20 @@ impl EventDispatcher {
         // Events that need to be maintained without re-firing between event updates should be managed here
         for (index, events) in &self.previous_events {
             // Mouse is currently pressed for this node
-            if self.is_mouse_pressed && events.contains(&EventType::MouseDown(Default::default())) {
+            if self.is_left_mouse_pressed && events.contains(&EventType::MouseLeftDown(Default::default())) {
                 // Make sure this event isn't removed while mouse is still held down
                 Self::insert_event(
                     &mut next_events,
                     index,
-                    EventType::MouseDown(Default::default()),
+                    EventType::MouseLeftDown(Default::default()),
+                );
+            }
+            if self.is_right_mouse_pressed && events.contains(&EventType::MouseRightDown(Default::default())) {
+                // Make sure this event isn't removed while mouse is still held down
+                Self::insert_event(
+                    &mut next_events,
+                    index,
+                    EventType::MouseRightDown(Default::default()),
                 );
             }
 
@@ -332,7 +350,8 @@ impl EventDispatcher {
             self.contains_cursor = None;
             self.wants_cursor = None;
             self.next_mouse_position = self.current_mouse_position;
-            self.next_mouse_pressed = self.is_mouse_pressed;
+            self.next_left_mouse_pressed = self.is_left_mouse_pressed;
+            self.next_right_mouse_pressed = self.is_right_mouse_pressed;
 
             // --- Pre-Process --- //
             // We pre-process some events so that we can provide accurate event data (such as if the mouse is pressed)
@@ -343,16 +362,25 @@ impl EventDispatcher {
                     self.next_mouse_position = *point;
                 }
 
-                if matches!(input_event, InputEvent::MouseLeftPress) {
-                    // Reset next global mouse pressed
-                    self.next_mouse_pressed = true;
-                    break;
-                } else if matches!(input_event, InputEvent::MouseLeftRelease) {
-                    // Reset next global mouse pressed
-                    self.next_mouse_pressed = false;
-                    // Reset global cursor container
-                    self.has_cursor = None;
-                    break;
+                match input_event{
+                    InputEvent::MouseMoved(point) => {
+                        self.next_mouse_position = *point;
+                    },
+                    InputEvent::MouseLeftPress => {
+                        self.next_left_mouse_pressed = true;
+                    },
+                    InputEvent::MouseLeftRelease => {
+                        self.next_left_mouse_pressed = false;
+                        self.has_cursor = None;
+                    },
+                    InputEvent::MouseRightPress => {
+                        self.next_right_mouse_pressed = true;
+                    },
+                    InputEvent::MouseRightRelease => {
+                        self.next_right_mouse_pressed = false;
+                        self.has_cursor = None;
+                    },
+                    _ => ()
                 }
             }
 
@@ -486,7 +514,8 @@ impl EventDispatcher {
 
             // === Process Cursor States === //
             self.current_mouse_position = self.next_mouse_position;
-            self.is_mouse_pressed = self.next_mouse_pressed;
+            self.is_left_mouse_pressed = self.next_left_mouse_pressed;
+            self.is_right_mouse_pressed = self.next_right_mouse_pressed;
 
             if self.hovered.is_none() {
                 // No change -> revert
@@ -595,7 +624,34 @@ impl EventDispatcher {
                             states,
                             (node, depth),
                             &layout,
-                            EventType::MouseDown(cursor_event),
+                            EventType::MouseLeftDown(cursor_event),
+                        );
+
+                        if world.get::<Focusable>(node.0).is_some() {
+                            Self::update_state(states, (node, depth), &layout, EventType::Focus);
+                        }
+
+                        if self.has_cursor.is_none() {
+                            if let Some(styles) = world.get::<ComputedStyles>(node.0) {
+                                // Check if the cursor moved onto a widget that qualifies as one that can contain it
+                                if Self::can_contain_cursor(&styles.0) {
+                                    self.has_cursor = Some(node);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            InputEvent::MouseRightPress => {
+                if let Some(layout) = context.get_layout(&node) {
+                    if ignore_layout || layout.contains(&self.current_mouse_position) {
+                        let cursor_event = self.get_cursor_event(self.current_mouse_position);
+                        // event_stream.push(Event::new(node.0, EventType::MouseDown(cursor_event)));
+                        Self::update_state(
+                            states,
+                            (node, depth),
+                            &layout,
+                            EventType::MouseRightDown(cursor_event),
                         );
 
                         if world.get::<Focusable>(node.0).is_some() {
@@ -622,20 +678,48 @@ impl EventDispatcher {
                             states,
                             (node, depth),
                             &layout,
-                            EventType::MouseUp(cursor_event),
+                            EventType::MouseLeftUp(cursor_event),
                         );
                         // self.last_clicked.set(node);
 
                         if Self::contains_event(
                             &self.previous_events,
                             &node,
-                            &EventType::MouseDown(cursor_event),
+                            &EventType::MouseLeftDown(cursor_event),
                         ) {
                             Self::update_state(
                                 states,
                                 (node, depth),
                                 &layout,
-                                EventType::Click(cursor_event),
+                                EventType::LeftClick(cursor_event),
+                            );
+                        }
+                    }
+                }
+            }
+            InputEvent::MouseRightRelease => {
+                if let Some(layout) = context.get_layout(&node) {
+                    if ignore_layout || layout.contains(&self.current_mouse_position) {
+                        let cursor_event = self.get_cursor_event(self.current_mouse_position);
+                        // event_stream.push(Event::new(node.0, EventType::MouseUp(cursor_event)));
+                        Self::update_state(
+                            states,
+                            (node, depth),
+                            &layout,
+                            EventType::MouseRightUp(cursor_event),
+                        );
+                        // self.last_clicked.set(node);
+
+                        if Self::contains_event(
+                            &self.previous_events,
+                            &node,
+                            &EventType::MouseRightDown(cursor_event),
+                        ) {
+                            Self::update_state(
+                                states,
+                                (node, depth),
+                                &layout,
+                                EventType::RightClick(cursor_event),
                             );
                         }
                     }
@@ -675,8 +759,8 @@ impl EventDispatcher {
     }
 
     fn get_cursor_event(&self, position: (f32, f32)) -> CursorEvent {
-        let change = self.next_mouse_pressed != self.is_mouse_pressed;
-        let pressed = self.next_mouse_pressed;
+        let change = (self.next_left_mouse_pressed != self.is_left_mouse_pressed) | (self.next_right_mouse_pressed != self.is_right_mouse_pressed);
+        let pressed = self.next_left_mouse_pressed | self.next_right_mouse_pressed;
         CursorEvent {
             position,
             pressed,
@@ -841,8 +925,10 @@ impl EventDispatcher {
         // Merge only what could be changed internally. External changes (i.e. from Context)
         // should not be touched
         // self.last_clicked = from.last_clicked;
-        self.is_mouse_pressed = from.is_mouse_pressed;
-        self.next_mouse_pressed = from.next_mouse_pressed;
+        self.is_left_mouse_pressed = from.is_left_mouse_pressed;
+        self.is_right_mouse_pressed = from.is_right_mouse_pressed;
+        self.next_left_mouse_pressed = from.next_left_mouse_pressed;
+        self.next_right_mouse_pressed = from.next_right_mouse_pressed;
         self.current_mouse_position = from.current_mouse_position;
         self.next_mouse_position = from.next_mouse_position;
         self.previous_events = from.previous_events;

--- a/src/input.rs
+++ b/src/input.rs
@@ -70,7 +70,7 @@ pub(crate) fn process_events(world: &mut World) {
 
             for event in custom_event_mouse_button.0.iter(&mouse_button_input_events) {
                 match event.button{
-                    MouseButton::Left => {
+                    MouseButton::Left => {                    //MouseButton::Other(_) => todo!(),
                         if event.state == ButtonState::Pressed {
                             input_events.push(InputEvent::MouseLeftPress);
                         } else if event.state == ButtonState::Released {
@@ -84,7 +84,13 @@ pub(crate) fn process_events(world: &mut World) {
                             input_events.push(InputEvent::MouseRightRelease);
                         }
                     },
-                    MouseButton::Middle => todo!(),
+                    MouseButton::Middle => {
+                        if event.state == ButtonState::Pressed {
+                            input_events.push(InputEvent::MouseMiddlePress);
+                        } else if event.state == ButtonState::Released {
+                            input_events.push(InputEvent::MouseMiddleRelease);
+                        }
+                    },
                     _ => ()
                 }
             }

--- a/src/input.rs
+++ b/src/input.rs
@@ -69,12 +69,23 @@ pub(crate) fn process_events(world: &mut World) {
             }
 
             for event in custom_event_mouse_button.0.iter(&mouse_button_input_events) {
-                if let MouseButton::Left = event.button {
-                    if event.state == ButtonState::Pressed {
-                        input_events.push(InputEvent::MouseLeftPress);
-                    } else if event.state == ButtonState::Released {
-                        input_events.push(InputEvent::MouseLeftRelease);
-                    }
+                match event.button{
+                    MouseButton::Left => {
+                        if event.state == ButtonState::Pressed {
+                            input_events.push(InputEvent::MouseLeftPress);
+                        } else if event.state == ButtonState::Released {
+                            input_events.push(InputEvent::MouseLeftRelease);
+                        }
+                    },
+                    MouseButton::Right => {
+                        if event.state == ButtonState::Pressed {
+                            input_events.push(InputEvent::MouseRightPress);
+                        } else if event.state == ButtonState::Released {
+                            input_events.push(InputEvent::MouseRightRelease);
+                        }
+                    },
+                    MouseButton::Middle => todo!(),
+                    _ => ()
                 }
             }
 

--- a/src/input_event.rs
+++ b/src/input_event.rs
@@ -9,6 +9,10 @@ pub enum InputEvent {
     MouseLeftPress,
     /// An event that occurs when the user releases the left mouse button
     MouseLeftRelease,
+    /// An event that occurs when the user presses the right mouse button
+    MouseRightPress,
+    /// An event that occurs when the user releases the right mouse button
+    MouseRightRelease,
     /// An event that occurs when the user scrolls
     Scroll { dx: f32, dy: f32, is_line: bool },
     /// An event that occurs when the user types in a character
@@ -34,6 +38,8 @@ impl InputEvent {
             Self::MouseMoved(..) => InputEventCategory::Mouse,
             Self::MouseLeftPress => InputEventCategory::Mouse,
             Self::MouseLeftRelease => InputEventCategory::Mouse,
+            Self::MouseRightPress => InputEventCategory::Mouse,
+            Self::MouseRightRelease => InputEventCategory::Mouse,
             Self::Scroll { .. } => InputEventCategory::Mouse,
             // Keyboard events
             Self::CharEvent { .. } => InputEventCategory::Keyboard,

--- a/src/input_event.rs
+++ b/src/input_event.rs
@@ -13,6 +13,10 @@ pub enum InputEvent {
     MouseRightPress,
     /// An event that occurs when the user releases the right mouse button
     MouseRightRelease,
+    /// An event that occurs when the user presses the right mouse button
+    MouseMiddlePress,
+    /// An event that occurs when the user presses the right mouse button
+    MouseMiddleRelease,
     /// An event that occurs when the user scrolls
     Scroll { dx: f32, dy: f32, is_line: bool },
     /// An event that occurs when the user types in a character
@@ -40,6 +44,8 @@ impl InputEvent {
             Self::MouseLeftRelease => InputEventCategory::Mouse,
             Self::MouseRightPress => InputEventCategory::Mouse,
             Self::MouseRightRelease => InputEventCategory::Mouse,
+            Self::MouseMiddlePress => InputEventCategory::Mouse,
+            Self::MouseMiddleRelease => InputEventCategory::Mouse,
             Self::Scroll { .. } => InputEventCategory::Mouse,
             // Keyboard events
             Self::CharEvent { .. } => InputEventCategory::Keyboard,

--- a/src/widgets/accordion/summary.rs
+++ b/src/widgets/accordion/summary.rs
@@ -81,7 +81,7 @@ pub fn render(
                         if let Ok(mut context) = query.get_mut(context_entity) {
                             event.stop_propagation();
                             event.prevent_default();
-                            if let EventType::Click(..) = event.event_type {
+                            if let EventType::LeftClick(..) = event.event_type {
                                 context.toggle_current(current_index);
                             }
                         }

--- a/src/widgets/scroll/scroll_bar.rs
+++ b/src/widgets/scroll/scroll_bar.rs
@@ -207,7 +207,7 @@ pub fn scroll_bar_render(
                           mut query: Query<&mut ScrollContext>| {
                         if let Ok(mut scroll_context) = query.get_mut(context_entity) {
                             match event.event_type {
-                                EventType::MouseDown(data) => {
+                                EventType::MouseLeftDown(data) => {
                                     // --- Capture Cursor --- //
                                     event_dispatcher_context.capture_cursor(event.current_target);
                                     scroll_context.start_pos = data.position.into();
@@ -257,7 +257,7 @@ pub fn scroll_bar_render(
                                     };
                                     scroll_context.start_offset = offset.into();
                                 }
-                                EventType::MouseUp(..) => {
+                                EventType::MouseLeftUp(..) => {
                                     // --- Release Cursor --- //
                                     event_dispatcher_context.release_cursor(event.current_target);
                                     scroll_context.is_dragging = false;

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -233,7 +233,7 @@ pub fn window_render(
                                             event.prevent_default();
                                             event.stop_propagation();
                                             match event.event_type {
-                                                EventType::MouseDown(data) => {
+                                                EventType::MouseLeftDown(data) => {
                                                     event_dispatcher_context.capture_cursor(entity);
                                                     window.is_dragging = true;
                                                     window.offset = Vec2::new(
@@ -241,7 +241,7 @@ pub fn window_render(
                                                         window.position.y - data.position.1,
                                                     );
                                                 }
-                                                EventType::MouseUp(..) => {
+                                                EventType::MouseLeftUp(..) => {
                                                     event_dispatcher_context.release_cursor(entity);
                                                     window.is_dragging = false;
                                                 }


### PR DESCRIPTION
Adds the ability to detect Right and Middle click on widgets.

Changes are breaking due to changes of Enum names. But relatively easy to fix existing code.

Existing:
```
if let EventType::Click(..) = event.event_type {
    ...
}       
```
New:
```
if let EventType::LeftClick(..) = event.event_type {
    ...
}       
```