### PR TITLE
Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,16 @@ exclude = ["assets/*", "screenshots/*", "book"]
 [workspace]
 members = ["kayak_ui_macros", "kayak_font"]
 
+[features]
+# SVG should be enabled by defualt when it works again
+default = []
+svg = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.11", default-features = false, features = ["bevy_render", "bevy_asset", "bevy_winit", "bevy_core_pipeline"] }
-bevy_svg = { version="0.11", default-features = false }
+bevy = { version = "0.12", default-features = false, features = ["bevy_render", "bevy_asset", "bevy_winit", "bevy_core_pipeline"] }
+# bevy_svg = { version="0.11", default-features = false }
 bitflags = "1.3.2"
 bytemuck = "1.12"
 dashmap = "5.4"
@@ -37,7 +42,7 @@ uuid = { version = "1.3", features = ["v4"] }
 [dev-dependencies]
 fastrand = "1.8"
 bevy-inspector-egui = "0.19"
-bevy = { version = "0.11", default-features = true }
+bevy = { version = "0.12", default-features = true }
 
 [[example]]
 name = "tabs"

--- a/kayak_font/Cargo.toml
+++ b/kayak_font/Cargo.toml
@@ -23,14 +23,15 @@ num-derive = "0.3"
 num-traits = "0.2"
 ttf-parser = "0.17"
 image = "0.24"
+futures-lite = "1.11.3"
 
 # Provides UAX #14 line break segmentation
 xi-unicode = "0.3"
 
-bevy = { version = "0.11", optional = true, default-features = false, features = ["bevy_asset", "bevy_render", "bevy_core_pipeline"] }
+bevy = { version = "0.12", optional = true, default-features = false, features = ["bevy_asset", "bevy_render", "bevy_core_pipeline"] }
 
 [dev-dependencies]
-bevy = { version = "0.11" }
+bevy = { version = "0.12" }
 bytemuck = "1.12.0"
 
 [package.metadata.docs.rs]

--- a/kayak_font/src/bevy/font_texture.rs
+++ b/kayak_font/src/bevy/font_texture.rs
@@ -1,30 +1,30 @@
 use crate::KayakFont;
-use bevy::prelude::{AssetEvent, Assets, EventReader, Handle, Image, Local, Res, ResMut};
-use bevy::render::render_resource::{FilterMode, SamplerDescriptor, TextureFormat, TextureUsages};
-use bevy::render::texture::ImageSampler;
+use bevy::prelude::{AssetEvent, AssetId, Assets, EventReader, Image, Local, Res, ResMut};
+use bevy::render::render_resource::{TextureFormat, TextureUsages};
+use bevy::render::texture::{ImageFilterMode, ImageSampler, ImageSamplerDescriptor};
 
 pub fn init_font_texture(
-    mut not_processed: Local<Vec<Handle<KayakFont>>>,
+    mut not_processed: Local<Vec<AssetId<KayakFont>>>,
     mut font_events: EventReader<AssetEvent<KayakFont>>,
     mut images: ResMut<Assets<Image>>,
     fonts: Res<Assets<KayakFont>>,
 ) {
     // quick and dirty, run this for all textures anytime a texture is created.
-    for event in font_events.iter() {
-        if let AssetEvent::Created { handle } = event {
-            not_processed.push(handle.clone_weak());
+    for event in font_events.read() {
+        if let AssetEvent::Added { id } = event {
+            not_processed.push(*id);
         }
     }
 
     let not_processed_fonts = not_processed.drain(..).collect::<Vec<_>>();
-    for font_handle in not_processed_fonts {
-        if let Some(font) = fonts.get(&font_handle) {
+    for font_id in not_processed_fonts {
+        if let Some(font) = fonts.get(font_id) {
             if let Some(texture) = images.get_mut(font.image.get()) {
                 texture.texture_descriptor.format = TextureFormat::Rgba8Unorm;
-                texture.sampler_descriptor = ImageSampler::Descriptor(SamplerDescriptor {
-                    label: Some("Present Sampler"),
-                    mag_filter: FilterMode::Linear,
-                    min_filter: FilterMode::Linear,
+                texture.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+                    label: Some("Present Sampler".into()),
+                    mag_filter: ImageFilterMode::Linear,
+                    min_filter: ImageFilterMode::Linear,
 
                     ..Default::default()
                 });
@@ -32,7 +32,7 @@ pub fn init_font_texture(
                     | TextureUsages::COPY_DST
                     | TextureUsages::COPY_SRC;
             } else {
-                not_processed.push(font_handle.clone_weak());
+                not_processed.push(font_id);
             }
         }
     }

--- a/kayak_font/src/bevy/mod.rs
+++ b/kayak_font/src/bevy/mod.rs
@@ -11,7 +11,7 @@ mod loader;
 mod renderer;
 
 mod plugin {
-    use bevy::prelude::{AddAsset, IntoSystemConfigs, Plugin, Update};
+    use bevy::prelude::{AssetApp, IntoSystemConfigs, Plugin, Update};
     use bevy::render::{ExtractSchedule, Render, RenderApp, RenderSet};
 
     use crate::bevy::font_texture::init_font_texture;
@@ -23,9 +23,9 @@ mod plugin {
 
     impl Plugin for KayakFontPlugin {
         fn build(&self, app: &mut bevy::prelude::App) {
-            app.add_asset::<KayakFont>()
-                .add_asset_loader(crate::ttf::loader::TTFLoader)
-                .add_asset_loader(KayakFontLoader)
+            app.init_asset::<KayakFont>()
+                .register_asset_loader(crate::ttf::loader::TTFLoader)
+                .register_asset_loader(KayakFontLoader)
                 .add_systems(Update, init_font_texture);
 
             let render_app = app.sub_app_mut(RenderApp);

--- a/kayak_font/src/font.rs
+++ b/kayak_font/src/font.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 #[cfg(feature = "bevy_renderer")]
 use bevy::{
+    asset::Asset,
     prelude::Handle,
     reflect::{TypePath, TypeUuid},
     render::texture::Image,
@@ -14,7 +15,7 @@ use crate::{
 };
 
 #[cfg(feature = "bevy_renderer")]
-#[derive(Debug, Clone, TypeUuid, TypePath, PartialEq)]
+#[derive(Asset, Debug, Clone, TypeUuid, TypePath, PartialEq)]
 #[uuid = "4fe4732c-6731-49bb-bafc-4690d636b848"]
 pub struct KayakFont {
     pub sdf: Sdf,

--- a/kayak_font/src/ttf/loader.rs
+++ b/kayak_font/src/ttf/loader.rs
@@ -1,12 +1,10 @@
 #![allow(clippy::needless_question_mark, clippy::question_mark)]
 use bevy::{
-    asset::{AssetLoader, LoadContext, LoadedAsset},
+    asset::{io::Reader, AssetLoader, LoadContext, LoadedAsset},
     render::render_resource::{Extent3d, TextureFormat},
     utils::{BoxedFuture, HashMap},
 };
-
-#[cfg(not(target_family = "wasm"))]
-use bevy::asset::FileAssetIo;
+use futures_lite::AsyncReadExt;
 
 use image::{EncodableLayout, RgbaImage};
 use nanoserde::DeJson;
@@ -27,11 +25,16 @@ pub struct Kttf {
 }
 
 impl AssetLoader for TTFLoader {
+    type Settings = ();
+    type Error = std::io::Error;
+    type Asset = KayakFont;
+
     fn load<'a>(
         &'a self,
-        bytes: &'a [u8],
+        reader: &'a mut Reader,
+        _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<(), anyhow::Error>> {
+    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
         Box::pin(async move {
             #[cfg(not(target_family = "wasm"))]
             let asset_io = load_context

--- a/src/render/material/pipeline.rs
+++ b/src/render/material/pipeline.rs
@@ -28,10 +28,11 @@ use kayak_font::bevy::FontTextureCache;
 use std::hash::Hash;
 use std::marker::PhantomData;
 
+#[cfg(feature = "svg")]
+use crate::render::svg::RenderSvgs;
 use crate::render::{
     extract::UIExtractedView,
     opacity_layer::OpacityLayerManager,
-    svg::RenderSvgs,
     ui_pass::{TransparentOpacityUI, TransparentUI},
     unified::pipeline::{
         queue_quads_inner, DrawUIDraw, ExtractedQuad, ImageBindGroups, PreviousClip, PreviousIndex,
@@ -300,7 +301,7 @@ impl<P: PhaseItem, M: MaterialUI, const I: usize> RenderCommand<P> for SetMateri
 }
 
 pub fn queue_material_ui_quads<M: MaterialUI>(
-    render_svgs: Res<RenderSvgs>,
+    #[cfg(feature = "svg")] render_svgs: Res<RenderSvgs>,
     opacity_layers: Res<OpacityLayerManager>,
     mut commands: Commands,
     draw_functions: Res<DrawFunctions<TransparentUI>>,
@@ -391,6 +392,7 @@ pub fn queue_material_ui_quads<M: MaterialUI>(
                     &mut image_bind_groups,
                     &gpu_images,
                     &quad_pipeline,
+                    #[cfg(feature = "svg")]
                     &render_svgs,
                     &mut transparent_phase,
                     &mut opacity_transparent_phase,

--- a/src/render/material/plugin.rs
+++ b/src/render/material/plugin.rs
@@ -1,9 +1,8 @@
 use bevy::{
     prelude::*,
     render::{
-        extract_component::ExtractComponentPlugin, render_asset::PrepareAssetSet,
-        render_phase::AddRenderCommand, render_resource::SpecializedRenderPipelines, Render,
-        RenderApp, RenderSet,
+        extract_component::ExtractComponentPlugin, render_phase::AddRenderCommand,
+        render_resource::SpecializedRenderPipelines, Render, RenderApp, RenderSet,
     },
 };
 use std::hash::Hash;
@@ -47,9 +46,7 @@ where
             .add_systems(
                 Render,
                 (
-                    prepare_materials_ui::<M>
-                        .in_set(RenderSet::Prepare)
-                        .after(PrepareAssetSet::PreAssetPrepare),
+                    prepare_materials_ui::<M>.in_set(RenderSet::Prepare),
                     queue_material_ui_quads::<M>
                         .in_set(RenderSet::Queue)
                         .after(crate::render::unified::pipeline::queue_quads),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,7 +4,7 @@ use bevy::{
         camera::RenderTarget,
         render_asset::RenderAssets,
         render_graph::{RenderGraph, RunGraphOnViewNode},
-        render_phase::{batch_phase_system, sort_phase_system, DrawFunctions, RenderPhase},
+        render_phase::{DrawFunctions, RenderPhase},
         Extract, ExtractSchedule, Render, RenderApp, RenderSet,
     },
     window::{PrimaryWindow, Window, WindowRef},
@@ -28,6 +28,7 @@ pub mod material;
 pub(crate) mod nine_patch;
 mod opacity_layer;
 pub(crate) mod quad;
+#[cfg(feature = "svg")]
 pub(crate) mod svg;
 pub(crate) mod texture_atlas;
 mod ui_pass;
@@ -62,15 +63,6 @@ impl Plugin for BevyKayakUIRenderPlugin {
                 prepare_opacity_layers
                     .in_set(RenderSet::Queue)
                     .before(unified::pipeline::queue_quads),
-            )
-            .add_systems(
-                Render,
-                (
-                    batch_phase_system::<TransparentUI>.after(sort_phase_system::<TransparentUI>),
-                    batch_phase_system::<TransparentOpacityUI>
-                        .after(sort_phase_system::<TransparentOpacityUI>),
-                )
-                    .in_set(RenderSet::PhaseSort),
             );
 
         // let pass_node_ui = MainPassUINode::new(&mut render_app.world);

--- a/src/render/ui_pass.rs
+++ b/src/render/ui_pass.rs
@@ -4,7 +4,7 @@ use bevy::ecs::prelude::*;
 use bevy::prelude::{Color, Image};
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{
-    BatchedPhaseItem, CachedRenderPipelinePhaseItem, DrawFunctionId, DrawFunctions, PhaseItem,
+    CachedRenderPipelinePhaseItem, DrawFunctionId, DrawFunctions, PhaseItem,
 };
 use bevy::render::render_resource::{CachedRenderPipelineId, RenderPassColorAttachment};
 use bevy::render::{
@@ -75,16 +75,6 @@ impl PhaseItem for TransparentUI {
     }
 }
 
-impl BatchedPhaseItem for TransparentUI {
-    fn batch_range(&self) -> &Option<Range<u32>> {
-        &self.batch_range
-    }
-
-    fn batch_range_mut(&mut self) -> &mut Option<Range<u32>> {
-        &mut self.batch_range
-    }
-}
-
 impl CachedRenderPipelinePhaseItem for TransparentUI {
     #[inline]
     fn cached_pipeline(&self) -> CachedRenderPipelineId {
@@ -137,16 +127,6 @@ impl PhaseItem for TransparentOpacityUI {
 
     fn entity(&self) -> Entity {
         self.entity
-    }
-}
-
-impl BatchedPhaseItem for TransparentOpacityUI {
-    fn batch_range(&self) -> &Option<Range<u32>> {
-        &self.batch_range
-    }
-
-    fn batch_range_mut(&mut self) -> &mut Option<Range<u32>> {
-        &mut self.batch_range
     }
 }
 

--- a/src/render_primitive.rs
+++ b/src/render_primitive.rs
@@ -1,12 +1,14 @@
 use bevy::prelude::*;
 use kayak_font::KayakFont;
 
+#[cfg(feature = "svg")]
+use crate::styles::StyleProp;
 use crate::{
     render::{
         font::FontMapping,
         unified::pipeline::{ExtractedQuad, ExtractedQuads, UIQuadType},
     },
-    styles::{Corner, KStyle, RenderCommand, StyleProp},
+    styles::{Corner, KStyle, RenderCommand},
 };
 
 pub trait RenderPrimitive {
@@ -206,6 +208,7 @@ impl RenderPrimitive for KStyle {
                     extracted_quads.quads.extend(nines);
                 }
             }
+            #[cfg(feature = "svg")]
             RenderCommand::Svg { handle } => {
                 let svgs = crate::render::svg::extract_svg(
                     camera_entity,

--- a/src/styles/render_command.rs
+++ b/src/styles/render_command.rs
@@ -2,6 +2,7 @@ use bevy::{
     prelude::{Handle, Image, Vec2},
     reflect::Reflect,
 };
+#[cfg(feature = "svg")]
 use bevy_svg::prelude::Svg;
 use kayak_font::{Alignment, TextLayout, TextProperties};
 
@@ -34,6 +35,7 @@ pub enum RenderCommand {
         border: Edge<f32>,
         handle: Handle<Image>,
     },
+    #[cfg(feature = "svg")]
     Svg {
         handle: Handle<Svg>,
     },

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -22,17 +22,20 @@
 
 use bevy::prelude::*;
 
+#[cfg(feature = "svg")]
 mod accordion;
 mod app;
 mod background;
 mod button;
 mod clip;
 mod element;
+#[cfg(feature = "svg")]
 mod icons;
 mod image;
 mod modal;
 mod nine_patch;
 mod scroll;
+#[cfg(feature = "svg")]
 mod svg;
 mod text;
 mod text_box;
@@ -41,12 +44,14 @@ mod transition;
 mod window;
 mod window_context_provider;
 
+#[cfg(feature = "svg")]
 pub use accordion::*;
 pub use app::{KayakApp, KayakAppBundle};
 pub use background::{Background, BackgroundBundle};
 pub use button::{ButtonState, KButton, KButtonBundle};
 pub use clip::{Clip, ClipBundle};
 pub use element::{Element, ElementBundle};
+#[cfg(feature = "svg")]
 pub use icons::*;
 pub use image::{KImage, KImageBundle};
 pub use modal::{Modal, ModalBundle};
@@ -59,6 +64,7 @@ pub use scroll::{
         ScrollContext, ScrollContextProvider, ScrollContextProviderBundle, ScrollMode,
     },
 };
+#[cfg(feature = "svg")]
 pub use svg::{KSvg, KSvgBundle, Svg};
 pub use text::{TextProps, TextWidgetBundle};
 pub use text_box::{TextBoxBundle, TextBoxProps, TextBoxState};
@@ -83,6 +89,7 @@ use scroll::{
     scroll_bar::scroll_bar_render, scroll_box::scroll_box_render,
     scroll_content::scroll_content_render, scroll_context::scroll_context_render,
 };
+#[cfg(feature = "svg")]
 use svg::svg_render;
 use text::text_render;
 use text_box::text_box_render;
@@ -101,6 +108,7 @@ pub struct KayakWidgets;
 
 impl Plugin for KayakWidgets {
     fn build(&self, app: &mut bevy::prelude::App) {
+        #[cfg(feature = "svg")]
         app.add_plugins(icons::IconsPlugin);
         app.add_systems(
             PostUpdate,
@@ -114,6 +122,7 @@ pub struct KayakWidgetsContextPlugin;
 
 impl KayakUIPlugin for KayakWidgetsContextPlugin {
     fn build(&self, context: &mut KayakRootContext) {
+        #[cfg(feature = "svg")]
         context.add_plugin(AccordionPlugin);
         context.add_widget_data::<KayakApp, EmptyState>();
         context.add_widget_data::<KButton, ButtonState>();
@@ -125,6 +134,7 @@ impl KayakUIPlugin for KayakWidgetsContextPlugin {
         context.add_widget_data::<KImage, EmptyState>();
         context.add_widget_data::<TextureAtlasProps, EmptyState>();
         context.add_widget_data::<NinePatch, EmptyState>();
+        #[cfg(feature = "svg")]
         context.add_widget_data::<KSvg, EmptyState>();
         context.add_widget_data::<Element, EmptyState>();
         context.add_widget_data::<ScrollBarProps, EmptyState>();
@@ -181,6 +191,7 @@ impl KayakUIPlugin for KayakWidgetsContextPlugin {
             widget_update::<NinePatch, EmptyState>,
             nine_patch_render,
         );
+        #[cfg(feature = "svg")]
         context.add_widget_system(
             KSvg::default().get_name(),
             widget_update::<KSvg, EmptyState>,


### PR DESCRIPTION
Includes some work to put svg behind a feature flag, which reduces deps for people who don't use it, and makes migrating easier while bevy_svg hasn't been migrated yet.

Big issues for this migration would be:
- The asset migration, especially changes to asset loaders, asset events, and load_internal changing to a new embedded asset approach
- Rendering changes, especially those introduced by https://github.com/bevyengine/bevy/pull/9236